### PR TITLE
Add language from database to est and ms text endpoint responses

### DIFF
--- a/sls_api/endpoints/text.py
+++ b/sls_api/endpoints/text.py
@@ -165,7 +165,7 @@ def get_reading_text(project, collection_id, publication_id, section_id=None, la
                                   {"bookId": bookId, "sectionId": section_id})
         else:
             content = get_content(project, "est", filename, xsl_file, {"bookId": bookId})
-        
+
         select = "SELECT language FROM publication WHERE id = :p_id"
         statement = sqlalchemy.sql.text(select).bindparams(p_id=publication_id)
         result = connection.execute(statement).fetchone()


### PR DESCRIPTION
If the language of an established text or a manuscript is defined in the database, include the language value in the endpoint response. This is needed for the frontend to correctly add lang-attributes to the HTML in case the texts are in a different language than the user interface.

This commit also removes

```
if language is not None:
       data["language"] = language
```

from the est endpoint because there is no need to include the request language in the response.