### PR TITLE
feature: support multilingual collections

### DIFF
--- a/sls_api/endpoints/metadata.py
+++ b/sls_api/endpoints/metadata.py
@@ -257,15 +257,9 @@ def get_collections(project, language=None):
         return jsonify({"msg": "No such project."}), 400
     else:
         if language is None:
-            logger.info(
-                "Getting collections /{}/collections".format(project)
-            )
+            logger.info("Getting collections /{}/collections".format(project))
         else:
-            logger.info(
-                "Getting collections /{}/collections/{}".format(
-                    project, language
-                )
-            )
+            logger.info("Getting collections /{}/collections/{}".format(project, language))
 
         connection = db_engine.connect()
         status = 1 if config["show_internally_published"] else 2
@@ -302,11 +296,7 @@ def get_collections(project, language=None):
                     name """
         )
 
-        statement = sql.bindparams(
-            p_status=status,
-            p_id=project_id,
-            language=language
-        )
+        statement = sql.bindparams(p_status=status, p_id=project_id, language=language)
 
         results = []
         for row in connection.execute(statement).fetchall():

--- a/sls_api/endpoints/metadata.py
+++ b/sls_api/endpoints/metadata.py
@@ -250,19 +250,57 @@ def handle_toc(project, collection_id, language=None):
 
 
 @meta.route("/<project>/collections")
-def get_collections(project):
+@meta.route("/<project>/collections/<language>")
+def get_collections(project, language=None):
     config = get_project_config(project)
     if config is None:
         return jsonify({"msg": "No such project."}), 400
     else:
-        logger.info("Getting collections /{}/collections".format(project))
+        if language is None:
+            logger.info("Getting collections /{}/collections".format(project))
+        else:
+            logger.info("Getting collections /{}/collections/{}".format(project, language))
+
         connection = db_engine.connect()
         status = 1 if config["show_internally_published"] else 2
         project_id = get_project_id_from_name(project)
+
+        # The query attempts to find a translation for the `name` field in the 
+        # `translate_text` table. If there is no translation or `language` is None,
+        # the query falls back to the original `name` in the `publication_collection`
+        # table.
         sql = sqlalchemy.sql.text(
-            """ SELECT id, name as title, published, date_created, date_modified, date_published_externally, legacy_id,
-            project_id, publication_collection_title_id, publication_collection_introduction_id, name FROM publication_collection WHERE project_id = :p_id AND published>=:p_status ORDER BY name """)
-        statement = sql.bindparams(p_status=status, p_id=project_id)
+            """ SELECT 
+                    pc.id, 
+                    COALESCE(tt.text, pc.name) as title, 
+                    pc.published, 
+                    pc.legacy_id,
+                    pc.project_id, 
+                    pc.publication_collection_title_id, 
+                    pc.publication_collection_introduction_id, 
+                    COALESCE(tt.text, pc.name) as name
+                FROM 
+                    publication_collection pc
+                LEFT JOIN 
+                    translation_text tt
+                ON 
+                    pc.name_translation_id = tt.translation_id 
+                    AND tt.language = :language 
+                    AND tt.deleted = 0 
+                WHERE 
+                    pc.project_id = :p_id 
+                    AND pc.published >= :p_status 
+                    AND pc.deleted = 0 
+                ORDER BY 
+                    name """
+        )
+
+        statement = sql.bindparams(
+            p_status=status, 
+            p_id=project_id, 
+            language=language
+        )
+
         results = []
         for row in connection.execute(statement).fetchall():
             if row is not None:

--- a/sls_api/endpoints/metadata.py
+++ b/sls_api/endpoints/metadata.py
@@ -257,47 +257,54 @@ def get_collections(project, language=None):
         return jsonify({"msg": "No such project."}), 400
     else:
         if language is None:
-            logger.info("Getting collections /{}/collections".format(project))
+            logger.info(
+                "Getting collections /{}/collections".format(project)
+            )
         else:
-            logger.info("Getting collections /{}/collections/{}".format(project, language))
+            logger.info(
+                "Getting collections /{}/collections/{}".format(
+                    project, language
+                )
+            )
 
         connection = db_engine.connect()
         status = 1 if config["show_internally_published"] else 2
         project_id = get_project_id_from_name(project)
 
-        # The query attempts to find a translation for the `name` field in the 
-        # `translate_text` table. If there is no translation or `language` is None,
-        # the query falls back to the original `name` in the `publication_collection`
+        # The query attempts to find a translation for the `name`
+        # field in the `translate_text` table. If there is no
+        # translation or `language` is None, the query falls back
+        # to the original `name` in the `publication_collection`
         # table.
         sql = sqlalchemy.sql.text(
-            """ SELECT 
-                    pc.id, 
-                    COALESCE(tt.text, pc.name) as title, 
-                    pc.published, 
+            """ SELECT
+                    pc.id,
+                    COALESCE(tt.text, pc.name) as title,
+                    pc.published,
                     pc.legacy_id,
-                    pc.project_id, 
-                    pc.publication_collection_title_id, 
-                    pc.publication_collection_introduction_id, 
+                    pc.project_id,
+                    pc.publication_collection_title_id,
+                    pc.publication_collection_introduction_id,
                     COALESCE(tt.text, pc.name) as name
-                FROM 
+                FROM
                     publication_collection pc
-                LEFT JOIN 
+                LEFT JOIN
                     translation_text tt
-                ON 
-                    pc.name_translation_id = tt.translation_id 
-                    AND tt.language = :language 
-                    AND tt.deleted = 0 
-                WHERE 
-                    pc.project_id = :p_id 
-                    AND pc.published >= :p_status 
-                    AND pc.deleted = 0 
-                ORDER BY 
+                ON
+                    pc.name_translation_id = tt.translation_id
+                    AND tt.language = :language
+                    AND tt.deleted = 0
+                WHERE
+                    pc.project_id = :p_id
+                    AND pc.published >= :p_status
+                    AND pc.deleted = 0
+                ORDER BY
                     name """
         )
 
         statement = sql.bindparams(
-            p_status=status, 
-            p_id=project_id, 
+            p_status=status,
+            p_id=project_id,
             language=language
         )
 


### PR DESCRIPTION
This update modifies the endpoints for getting all publication collections as well as a specific collection with a language parameter, so the names of the collections can be fetched in a specific language:

```
@meta.route("/<project>/collections")
@meta.route("/<project>/collections/<language>")
```

```
@meta.route("/<project>/collection/<collection_id>")
@meta.route("/<project>/collection/<collection_id>/i18n/<language>")
```

The new frontend already supports these endpoints, and, for instance, they are required for the English and Arabic versions of granqvist.sls.fi to work with the new frontend.

**Required database modification:** This update requires that a column named `name_translation_id` is added to the `publication_collection` table in the digital edition database. It should be of type BIGINT. The field is used to point to translations of the collection name in the `translation_text` table.