### PR TITLE
fix: set CORS header for `get_pdf_file` endpoint

### DIFF
--- a/sls_api/configs/digital_editions_example.yml
+++ b/sls_api/configs/digital_editions_example.yml
@@ -22,6 +22,15 @@ parland:
     disabled_publications: [10,12,13,14,9,20,28]
     # SQLAlchemy engine string for comments (edith) database
     comments_database: 'mysql://${MYSQL_USER}:${MYSQL_PASSWORD}@mysql_server.example.com:3306?charset=utf8mb4/parland_comments'
+    # List of origins to allow CORS requests from. Typically, you would put
+    # at least the origin of the project frontend here. This list can include
+    # multiple origins if the project needs to be accessible from different
+    # domains or environments (e.g., staging, production).
+    # Ensure that only trusted origins are added to prevent unauthorized
+    # cross-origin requests.
+    # Currently only used to set response headers on downloadable PDFs and
+    # EPUBs in the `get_pdf_file` endpoint in `endpoints/media.py`.
+    allowed_cors_origins: ["https://parland.sls.fi"]
 
 topelius:
     # First, settings about how the publication tools should communicate towards git
@@ -35,6 +44,15 @@ topelius:
     disabled_publications: [10,12,13,14,9,20,28]
     # SQLAlchemy engine string for comments (edith) database
     comments_database: 'mysql://${MYSQL_USER}:${MYSQL_PASSWORD}@mysql_server.example.com:3306?charset=utf8mb4/topelius_comments'
+    # List of origins to allow CORS requests from. Typically, you would put
+    # at least the origin of the project frontend here. This list can include
+    # multiple origins if the project needs to be accessible from different
+    # domains or environments (e.g., staging, production).
+    # Ensure that only trusted origins are added to prevent unauthorized
+    # cross-origin requests.
+    # Currently only used to set response headers on downloadable PDFs and
+    # EPUBs in the `get_pdf_file` endpoint in `endpoints/media.py`.
+    allowed_cors_origins: ["https://topelius.sls.fi"]
 
 # XML-to-HTML is somewhat computationally expensive, so HTML reading texts are cached for up to this amount of time
 cache_lifetime_seconds: 7200  # 2 hours

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -561,3 +561,19 @@ def get_first_valid_item_from_toc(flattened_toc):
         if flattened_toc[i].get('itemId') is not None and flattened_toc[i].get('itemId') != '' and flattened_toc[i].get('type') is not None and flattened_toc[i].get('type') != 'subtitle' and flattened_toc[i].get('type') != 'section_title':
             return flattened_toc[i]
     return {}
+
+
+def get_allowed_cors_origins(project: str) -> list:
+    """
+    Retrieve the allowed CORS origins for a specific project.
+
+    Args:
+        project (str): The name of the project to get allowed CORS origins for.
+
+    Returns:
+        list: A list of allowed CORS origins for the project, or an empty list if none are found.
+    """
+    project_config = get_project_config(project)
+    if not project_config:
+        return []
+    return project_config.get("allowed_cors_origins", [])

--- a/sls_api/endpoints/media.py
+++ b/sls_api/endpoints/media.py
@@ -445,15 +445,15 @@ def get_pdf_file(project, collection_id, file_type, download_name, use_download_
 
             mimetype = "application/pdf"
             file_path = safe_join(config["file_root"],
-                                "downloads",
-                                collection_id,
-                                "{}.pdf".format(direct_download_name))
+                                  "downloads",
+                                  collection_id,
+                                  "{}.pdf".format(direct_download_name))
         elif 'epub' in str(file_type):
             mimetype = "application/epub+zip"
             file_path = safe_join(config["file_root"],
-                                "downloads",
-                                collection_id,
-                                "{}.epub".format(int(collection_id)))
+                                  "downloads",
+                                  collection_id,
+                                  "{}.epub".format(int(collection_id)))
     finally:
         connection.close()
 

--- a/sls_api/endpoints/media.py
+++ b/sls_api/endpoints/media.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, Response, send_file
+from flask import Blueprint, jsonify, Response, send_file, make_response, request
 import io
 import logging
 import sqlalchemy
@@ -414,46 +414,65 @@ def get_pdf_file(project, collection_id, file_type, download_name, use_download_
     """
     Retrieve a single file from project root
     Currently only PDF or ePub
+    Only allow requests from *.sls.fi subdomains
     """
     config = get_project_config(project)
     if config is None:
         return jsonify({"msg": "No such project."}), 400
+
     connection = db_engine.connect()
-    # Check that the collection exists
-    statement = sqlalchemy.sql.text("SELECT * FROM publication_collection WHERE id=:coll_id").bindparams(
-        coll_id=collection_id)
-    row = connection.execute(statement).fetchone()
-    if row is None:
-        return jsonify({
-            "msg": "Desired publication collection was not found in database!"
-        }), 404
+    try:
+        # Check that the collection exists
+        statement = sqlalchemy.sql.text("SELECT * FROM publication_collection WHERE id=:coll_id").bindparams(
+            coll_id=collection_id)
+        row = connection.execute(statement).fetchone()
+        if row is None:
+            return jsonify({
+                "msg": "Desired publication collection was not found in database!"
+            }), 404
 
-    file_path = ""
+        file_path = ""
+        mimetype = None
 
-    if use_download_name and 'pdf' in str(file_type):
-        if '.pdf' in str(download_name):
-            direct_download_name = download_name.split('.pdf')[0]
-        else:
-            direct_download_name = download_name
+        if 'pdf' in str(file_type):
+            if use_download_name:
+                if '.pdf' in str(download_name):
+                    direct_download_name = download_name.split('.pdf')[0]
+                else:
+                    direct_download_name = download_name
+            else:
+                direct_download_name = int(collection_id)
 
-        file_path = safe_join(config["file_root"],
-                              "downloads",
-                              collection_id,
-                              "{}.pdf".format(direct_download_name))
-    elif 'pdf' in str(file_type):
-        file_path = safe_join(config["file_root"],
-                              "downloads",
-                              collection_id,
-                              "{}.pdf".format(int(collection_id)))
-    elif 'epub' in str(file_type):
-        file_path = safe_join(config["file_root"],
-                              "downloads",
-                              collection_id,
-                              "{}.epub".format(int(collection_id)))
-    connection.close()
+            mimetype = "application/pdf"
+            file_path = safe_join(config["file_root"],
+                                "downloads",
+                                collection_id,
+                                "{}.pdf".format(direct_download_name))
+        elif 'epub' in str(file_type):
+            mimetype = "application/epub+zip"
+            file_path = safe_join(config["file_root"],
+                                "downloads",
+                                collection_id,
+                                "{}.epub".format(int(collection_id)))
+    finally:
+        connection.close()
 
     try:
-        return send_file(file_path, download_name=download_name, conditional=True)
+        response = make_response(
+            send_file(file_path, mimetype=mimetype, download_name=download_name, conditional=True)
+        )
+        # Dynamically set the Access-Control-Allow-Origin header
+        # to the request origin if the origin is a *.sls.fi subdomain.
+        # This makes it possible to embed PDFs served by the API on
+        # these sites.
+        # Ideally '.sls.fi' would not be hard-coded here, instead the
+        # main domain from where requests should be accepted could be
+        # read from the config.
+        origin = request.headers.get("Origin")
+        if origin and origin.endswith(".sls.fi"):
+            response.headers["Access-Control-Allow-Origin"] = origin
+            response.headers["Vary"] = "Origin"
+        return response
     except Exception:
         logger.exception(f"Failed sending file from {file_path}")
         return Response("File not found.", status=404, content_type="text/json")


### PR DESCRIPTION
Three changes:

1. Dynamically set the Access-Control-Allow-Origin header to the request origin if the origin is a *.sls.fi subdomain. This makes it possible to embed PDFs served by the API on these sites. For example, In the new frontend of granqvist.sls.fi PDF books are embedded in the web page. Currently the browser blocks these PDFs from being displayed embedded because of the lack of a Access-Control-Allow-Origin header in the response from api.sls.fi.

This is just a suggested fix, there might be a better solution. Currently the main domain "sls.fi" is hard-coded as an allowed origin, but it would be better if the allowed domain(s) would be read from the config.

3. Refactor if-elif code block setting `file_path` so there is only one branch per file type, and explicitly add mimetype to `send_file`.

4. Place the `connection.close()` call within a `finally` block to ensure connection closure on early returns.