### PR TITLE
Add missing field to tools endpoint returning list of publication collections

### DIFF
--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -376,14 +376,38 @@ def list_publication_collections(project):
     project_id = get_project_id_from_name(project)
     connection = db_engine.connect()
     # collections = get_table("publication_collection")
-    statement = """ SELECT pc.id, pc.name as title, pc.published, pc.date_created, pc.date_modified, pc.date_published_externally, pc.legacy_id,
-        pc.project_id, pc.publication_collection_title_id, pc.publication_collection_introduction_id, pc.name,
-        pct.original_filename AS collection_title_filename, pci.original_filename AS collection_intro_filename,
-        pct.published AS collection_title_published, pci.published AS collection_intro_published
-        FROM publication_collection pc
-        LEFT JOIN publication_collection_title pct ON pct.id = pc.publication_collection_title_id
-        LEFT JOIN publication_collection_introduction pci ON pci.id = pc.publication_collection_introduction_id
-        WHERE pc.project_id=:project_id AND pc.published>=1 ORDER BY pc.id """
+    statement = """
+        SELECT 
+            pc.id, 
+            pc.name AS title, 
+            pc.published, 
+            pc.date_created, 
+            pc.date_modified, 
+            pc.date_published_externally, 
+            pc.legacy_id,
+            pc.project_id, 
+            pc.publication_collection_title_id, 
+            pc.publication_collection_introduction_id, 
+            pc.name,
+            pct.original_filename AS collection_title_filename, 
+            pci.original_filename AS collection_intro_filename,
+            pct.published AS collection_title_published, 
+            pci.published AS collection_intro_published
+        FROM 
+            publication_collection pc
+        LEFT JOIN 
+            publication_collection_title pct 
+            ON pct.id = pc.publication_collection_title_id
+        LEFT JOIN 
+            publication_collection_introduction pci 
+            ON pci.id = pc.publication_collection_introduction_id
+        WHERE 
+            pc.project_id = :project_id 
+            AND pc.published >= 1 
+        ORDER BY 
+            pc.id
+    """
+
     statement = text(statement).bindparams(project_id=int_or_none(project_id))
     # statement = select(collections).where(collections.c.project_id == int_or_none(project_id))
     rows = connection.execute(statement).fetchall()

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -389,6 +389,7 @@ def list_publication_collections(project):
             pc.publication_collection_title_id, 
             pc.publication_collection_introduction_id, 
             pc.name,
+            pc.name_translation_id,
             pct.original_filename AS collection_title_filename, 
             pci.original_filename AS collection_intro_filename,
             pct.published AS collection_title_published, 

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -377,35 +377,35 @@ def list_publication_collections(project):
     connection = db_engine.connect()
     # collections = get_table("publication_collection")
     statement = """
-        SELECT 
-            pc.id, 
-            pc.name AS title, 
-            pc.published, 
-            pc.date_created, 
-            pc.date_modified, 
-            pc.date_published_externally, 
+        SELECT
+            pc.id,
+            pc.name AS title,
+            pc.published,
+            pc.date_created,
+            pc.date_modified,
+            pc.date_published_externally,
             pc.legacy_id,
-            pc.project_id, 
-            pc.publication_collection_title_id, 
-            pc.publication_collection_introduction_id, 
+            pc.project_id,
+            pc.publication_collection_title_id,
+            pc.publication_collection_introduction_id,
             pc.name,
             pc.name_translation_id,
-            pct.original_filename AS collection_title_filename, 
+            pct.original_filename AS collection_title_filename,
             pci.original_filename AS collection_intro_filename,
-            pct.published AS collection_title_published, 
+            pct.published AS collection_title_published,
             pci.published AS collection_intro_published
-        FROM 
+        FROM
             publication_collection pc
-        LEFT JOIN 
-            publication_collection_title pct 
+        LEFT JOIN
+            publication_collection_title pct
             ON pct.id = pc.publication_collection_title_id
-        LEFT JOIN 
-            publication_collection_introduction pci 
+        LEFT JOIN
+            publication_collection_introduction pci
             ON pci.id = pc.publication_collection_introduction_id
-        WHERE 
-            pc.project_id = :project_id 
-            AND pc.published >= 1 
-        ORDER BY 
+        WHERE
+            pc.project_id = :project_id
+            AND pc.published >= 1
+        ORDER BY
             pc.id
     """
 


### PR DESCRIPTION
The `name_translation_id` field was recently added to the `publication_collection` table. This pull request adds the field to the return value of the tools endpoint for listing all publication collections in a project.