### PR TITLE
refactor and fix tools-endpoints

### DIFF
--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -1,6 +1,6 @@
 import calendar
 from collections import OrderedDict
-from flask import jsonify
+from flask import jsonify, Response
 from flask_jwt_extended import get_jwt_identity, verify_jwt_in_request
 from functools import wraps
 import glob
@@ -14,7 +14,7 @@ from ruamel.yaml import YAML
 from sqlalchemy import create_engine, MetaData, Table
 from sqlalchemy.sql import select, text
 import time
-from typing import Any, Tuple, Optional
+from typing import Any, Optional, Tuple
 from werkzeug.security import safe_join
 
 ALLOWED_EXTENSIONS_FOR_FACSIMILE_UPLOAD = ["tif", "tiff", "png", "jpg", "jpeg"]
@@ -596,3 +596,51 @@ def validate_int(
     ):
         return False
     return True
+
+
+def create_success_response(
+    message: str,
+    data: Optional[Any] = None,
+    status_code: int = 200
+) -> Tuple[Response, int]:
+    """
+    Create a standardized JSON success response.
+
+    Args:
+
+        message (str): A message describing the success.
+        data (Any, optional): The data to include in the response. Defaults to None.
+        status_code (int, optional): The HTTP status code for the response. Defaults to 200.
+
+    Returns:
+
+        A tuple containing the Flask Response object with JSON data and the HTTP status code.
+    """
+    return jsonify({
+        "success": True,
+        "message": message,
+        "data": data
+    }), status_code
+
+
+def create_error_response(
+    message: str,
+    status_code: int = 400
+) -> Tuple[Response, int]:
+    """
+    Create a standardized JSON error response.
+
+    Args:
+
+        message (str): A message describing the error.
+        status_code (int, optional): The HTTP status code for the response. Defaults to 400.
+
+    Returns:
+
+        A tuple containing the Flask Response object with JSON data and the HTTP status code.
+    """
+    return jsonify({
+        "success": False,
+        "message": message,
+        "data": None
+    }), status_code

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -434,7 +434,7 @@ def create_translation(neutral, connection=None):
     """
     Inserts a new translation record with the provided neutral text and
     returns the generated ID.
-    
+
     If a connection is provided, it uses the existing connection. If no
     connection is provided, a new connection is created for the operation,
     and it will be closed automatically once the insertion is completed.
@@ -485,11 +485,31 @@ def create_translation_text(translation_id, table_name):
 def get_translation_text_id(translation_id, table_name, field_name, language):
     connection = db_engine.connect()
     if translation_id is not None:
-        stmt = """ SELECT id FROM translation_text WHERE
-                            (translation_id = :t_id AND (language is NULL OR language = 'not set') AND table_name = :table_name AND field_name = :field_name AND deleted = 0)
-                            OR (translation_id = :t_id AND language = :language AND table_name = :table_name AND field_name = :field_name AND language != 'not set' AND deleted = 0)
-                    LIMIT 1
-                """
+        stmt = """
+            SELECT id 
+            FROM translation_text 
+            WHERE 
+                (
+                    translation_id = :t_id 
+                    AND (
+                        language IS NULL 
+                        OR language = 'not set'
+                    )
+                    AND table_name = :table_name 
+                    AND field_name = :field_name 
+                    AND deleted = 0
+                ) 
+                OR 
+                (
+                    translation_id = :t_id 
+                    AND language = :language 
+                    AND table_name = :table_name 
+                    AND field_name = :field_name 
+                    AND language != 'not set' 
+                    AND deleted = 0
+                )
+            LIMIT 1
+        """
         statement = text(stmt).bindparams(t_id=translation_id, table_name=table_name, field_name=field_name, language=language)
         result = connection.execute(statement)
         row = result.fetchone()

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -562,11 +562,11 @@ def validate_project_name(name: str) -> Tuple[bool, Optional[str]]:
     """
     # Check length constraint
     if len(name) < 3 or len(name) > 32:
-        return False, "Project name must be no less than 3 and no more than 32 characters long."
+        return False, "'name' must be minimum 3 and maximum 32 characters in length."
 
     # Check allowed characters (lowercase letters a-z, digits 0-9 and underscores _)
     if not re.fullmatch(r'[a-z0-9_]+', name):
-        return False, "Project name can only contain lowercase letters a-z and digits 0-9."
+        return False, "'name' can only contain lowercase letters a-z and digits 0-9."
 
     return True, None
 

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -486,26 +486,26 @@ def get_translation_text_id(translation_id, table_name, field_name, language):
     connection = db_engine.connect()
     if translation_id is not None:
         stmt = """
-            SELECT id 
-            FROM translation_text 
-            WHERE 
+            SELECT id
+            FROM translation_text
+            WHERE
                 (
-                    translation_id = :t_id 
+                    translation_id = :t_id
                     AND (
-                        language IS NULL 
+                        language IS NULL
                         OR language = 'not set'
                     )
-                    AND table_name = :table_name 
-                    AND field_name = :field_name 
+                    AND table_name = :table_name
+                    AND field_name = :field_name
                     AND deleted = 0
-                ) 
-                OR 
+                )
+                OR
                 (
-                    translation_id = :t_id 
-                    AND language = :language 
-                    AND table_name = :table_name 
-                    AND field_name = :field_name 
-                    AND language != 'not set' 
+                    translation_id = :t_id
+                    AND language = :language
+                    AND table_name = :table_name
+                    AND field_name = :field_name
+                    AND language != 'not set'
                     AND deleted = 0
                 )
             LIMIT 1

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -165,15 +165,11 @@ def create_facsimile_collection(project):
                 inserted_row = result.fetchone()  # Fetch the inserted row
 
                 if inserted_row is None:
-                    # No row was returned; handle accordingly
                     return create_error_response("Insertion failed: no row returned.", 500)
-
-                # Convert the inserted_row to a dictionary for JSON serialization
-                inserted_row_dict = inserted_row._asdict()
 
                 return create_success_response(
                     message="Facsimile collection created.",
-                    data=inserted_row_dict,
+                    data=inserted_row._asdict(),
                     status_code=201
                 )
 
@@ -346,12 +342,9 @@ def edit_facsimile_collection(project, collection_id):
                     # No row was returned: invalid facsimile collection_id
                     return create_error_response("Update failed: no facsimile collection with the provided 'collection_id' found.")
 
-                # Convert the inserted row to a dict for JSON serialization
-                updated_row_dict = updated_row._asdict()
-
                 return create_success_response(
                     message="Facsimile collection updated.",
-                    data=updated_row_dict
+                    data=updated_row._asdict()
                 )
 
     except Exception as e:
@@ -737,15 +730,11 @@ def link_facsimile_collection_to_publication(project, collection_id):
                 inserted_row = connection.execute(ins_stmt).first()  # Fetch the inserted row
 
                 if inserted_row is None:
-                    # No row was returned; handle accordingly
                     return create_error_response("Insertion failed: no row returned.", 500)
-
-                # Convert the inserted row to a dict for JSON serialization
-                inserted_row_dict = inserted_row._asdict()
 
                 return create_success_response(
                     message="Facsimile created.",
-                    data=inserted_row_dict,
+                    data=inserted_row._asdict(),
                     status_code=201
                 )
 
@@ -918,15 +907,11 @@ def edit_facsimile(project):
                 updated_row = connection.execute(upd_stmt).first()
 
                 if updated_row is None:
-                    # No row was returned; handle accordingly
                     return create_error_response("Update failed: no facsimile with the provided 'id' found.")
-
-                # Convert the inserted row to a dict for JSON serialization
-                updated_row_dict = updated_row._asdict()
 
                 return create_success_response(
                     message="Publication facsimile updated.",
-                    data=updated_row_dict
+                    data=updated_row._asdict()
                 )
 
     except Exception as e:
@@ -1333,15 +1318,11 @@ def new_publication_collection(project):
                 inserted_row = connection.execute(statement).first()
 
                 if inserted_row is None:
-                    # No row was returned; handle accordingly
                     return create_error_response("Insertion failed: no row returned.", 500)
-
-                # Convert the inserted_row to a dictionary for JSON serialization
-                inserted_row_dict = inserted_row._asdict()
 
                 return create_success_response(
                     message="Publication collection created.",
-                    data=inserted_row_dict,
+                    data=inserted_row._asdict(),
                     status_code=201
                 )
 
@@ -1676,15 +1657,11 @@ def new_publication(project, collection_id):
                 inserted_row = connection.execute(insert_stmt).first()
 
                 if inserted_row is None:
-                    # No row was returned; handle accordingly
                     return create_error_response("Insertion failed: no row returned.", 500)
-
-                # Convert the inserted_row to a dictionary for JSON serialization
-                inserted_row_dict = inserted_row._asdict()
 
                 return create_success_response(
                     message="Publication created.",
-                    data=inserted_row_dict,
+                    data=inserted_row._asdict(),
                     status_code=201
                 )
 

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -122,7 +122,7 @@ def create_facsimile_collection(project):
                 else:
                     # Ensure remaining fields are strings
                     request_data[field] = str(request_data[field])
-                
+
                 # Add the field to the insert values
                 values[field] = request_data[field]
 

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -43,7 +43,19 @@ def create_facsimile_collection(project):
 
     Returns:
 
-        JSON: A success message with the inserted row or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the inserted facsimile
+       collection data; `null` on error.
 
     Example Request:
 
@@ -55,11 +67,12 @@ def create_facsimile_collection(project):
             "number_of_pages": 100
         }
 
-    Example Response (Success):
+    Example Success Response (HTTP 201):
 
         {
-            "msg": "Facsimile collection with ID 123 created successfully.",
-            "row": {
+            "success": true,
+            "message": "Facsimile collection created.",
+            "data": {
                 "id": 123,
                 "date_created": "2023-05-12T12:34:56",
                 "date_modified": "2023-06-01T08:22:11",
@@ -74,10 +87,12 @@ def create_facsimile_collection(project):
             }
         }
 
-    Example Response (Error):
+    Example Error Response (HTTP 400):
 
         {
-            "msg": "Field 'title' must be provided and cannot be empty."
+            "success": false,
+            "message": "Validation error: 'title' required.",
+            "data": null
         }
 
     Status Codes:
@@ -199,7 +214,19 @@ def edit_facsimile_collection(project, collection_id):
 
     Returns:
 
-        JSON: A success message with the updated row or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the updated facsimile
+       collection data; `null` on error.
 
     Example Request:
 
@@ -211,11 +238,12 @@ def edit_facsimile_collection(project, collection_id):
             "number_of_pages": 150
         }
 
-    Example Response (Success):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "Updated facsimile collection with ID 123 successfully.",
-            "row": {
+            "success": true,
+            "message": "Facsimile collection updated.",
+            "data": {
                 "id": 123,
                 "date_created": "2023-05-12T12:34:56",
                 "date_modified": "2023-06-01T08:22:11",
@@ -230,10 +258,12 @@ def edit_facsimile_collection(project, collection_id):
             }
         }
 
-    Example Response (Error):
+    Example Error Response (HTTP 400):
 
         {
-            "msg": "Invalid collection_id, must be a positive integer."
+            "success": false,
+            "message": "Validation error: 'collection_id' must be a positive integer.",
+            "data": null
         }
 
     Status Codes:
@@ -349,36 +379,53 @@ def list_facsimile_collections(project, order_by="id", direction="desc"):
 
     Returns:
 
-        JSON: A list with facsimile collection objects, an empty list
-        or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a list of facsimile collection objects;
+       `null` on error.
 
     Example Request:
 
         GET /projectname/facsimile_collection/list/
 
-    Example Response (Success):
-
-        [
-            {
-                "id": 123,
-                "date_created": "2023-05-12T12:34:56",
-                "date_modified": "2023-06-01T08:22:11",
-                "deleted": 0,
-                "title": "Facsimile Collection",
-                "number_of_pages": 150,
-                "start_page_number": 0,
-                "description": "Description of the collection.",
-                "folder_path": null,
-                "page_comment": null,
-                "external_url": null
-            },
-            ...
-        ]
-
-    Example Response (Error):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "Invalid project name."
+            "success": true,
+            "message": "Retrieved # records.",
+            "data": [
+                {
+                    "id": 123,
+                    "date_created": "2023-05-12T12:34:56",
+                    "date_modified": "2023-06-01T08:22:11",
+                    "deleted": 0,
+                    "title": "Facsimile Collection",
+                    "number_of_pages": 150,
+                    "start_page_number": 0,
+                    "description": "Description of the collection.",
+                    "folder_path": null,
+                    "page_comment": null,
+                    "external_url": null
+                },
+                ...
+            ]
+        }
+
+    Example Error Response (HTTP 400):
+
+        {
+            "success": false,
+            "message": "Validation error: 'project' does not exist.",
+            "data": null
         }
 
     Status Codes:
@@ -545,7 +592,19 @@ def link_facsimile_collection_to_publication(project, collection_id):
 
     Returns:
 
-        JSON: A success message with the inserted row or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the inserted facsimile
+       data; `null` on error.
 
     Example Request:
 
@@ -557,11 +616,12 @@ def link_facsimile_collection_to_publication(project, collection_id):
             "priority": 1
         }
 
-    Example Response (Success):
+    Example Success Response (HTTP 201):
 
         {
-            "msg": "Publication facsimile with ID 789 created successfully.",
-            "row": {
+            "success": true,
+            "message": "Facsimile created.",
+            "data": {
                 "id": 789,
                 "publication_facsimile_collection_id": 123,
                 "publication_id": 456,
@@ -577,18 +637,19 @@ def link_facsimile_collection_to_publication(project, collection_id):
             }
         }
 
-    Example Response (Error):
+    Example Error Response (HTTP 400):
 
         {
-            "msg": "Publication not found. Either project name or publication_id is invalid."
+            "success": false,
+            "message": "Validation error: 'publication_id' required.",
+            "data": null
         }
 
     Status Codes:
 
-    - 201 - Created: The facsimile was linked successfully.
-    - 400 - Bad Request: Invalid project name, collection ID, publication ID, or no data
-            provided.
-    - 404 - Not Found: The publication was not found for the given project or ID.
+    - 201 - Created: The facsimile was created successfully.
+    - 400 - Bad Request: Invalid project name, collection ID, publication ID,
+            or no data provided.
     - 500 - Internal Server Error: Database query or execution failed.
     """
     # Verify that project name is valid and get project_id
@@ -719,7 +780,19 @@ def edit_facsimile(project):
 
     Returns:
 
-        JSON: A success message with the updated row or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the updated facsimile data;
+      `null` on error.
 
     Example Request:
 
@@ -731,11 +804,12 @@ def edit_facsimile(project):
             "priority": 2
         }
 
-    Example Response (Success):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "Publication facsimile with ID 789 updated successfully.",
-            "row": {
+            "success": true,
+            "message": "Facsimile updated.",
+            "data": {
                 "id": 789,
                 "publication_facsimile_collection_id": 123,
                 "publication_id": 456,
@@ -751,17 +825,19 @@ def edit_facsimile(project):
             }
         }
 
-    Example Response (Error):
+    Example Error Response (HTTP 400):
 
         {
-            "msg": "Invalid 'id' field, must be a positive integer."
+            "success": false,
+            "message": "Validation error: 'id' must be a positive integer.",
+            "data": null
         }
 
     Status Codes:
 
     - 200 - OK: The facsimile was updated successfully.
-    - 400 - Bad Request: Invalid project name, facsimile ID, or no valid data provided.
-    - 404 - Not Found: The facsimile was not found for the given project or ID.
+    - 400 - Bad Request: Invalid project name, facsimile ID, or no valid
+            data provided.
     - 500 - Internal Server Error: Database query or execution failed.
     """
     # Verify that project name is valid and get project_id
@@ -881,31 +957,54 @@ def list_facsimile_collection_links(project, collection_id, order_by="id", direc
 
     Returns:
 
-        JSON: A list of facsimile objects with details or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a list of facsimile objects; `null` on error.
 
     Example Request:
 
         GET /projectname/facsimile_collection/123/list_links/
 
-    Example Response (Success):
-
-        [
-            {
-                "id": 456,
-                "publication_id": 789,
-                "publication_name": "Publication Title",
-                "page_number": 12,
-                "date_created": "2023-07-01T14:22:33",
-                "deleted": 0
-            },
-            ...
-        ]
-
-    Example Response (Error):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "Invalid collection_id, must be a positive integer."
+            "success": true,
+            "message": "Retrieved # records.",
+            "data": [
+                {
+                    "id": 456,
+                    "publication_facsimile_collection_id": 123,
+                    "publication_id": 789,
+                    "publication_manuscript_id": null,
+                    "publication_version_id": null,
+                    "date_created": "2023-05-12T12:34:56",
+                    "date_modified": "2023-06-01T08:22:11",
+                    "deleted": 0,
+                    "page_nr": 12,
+                    "section_id": 1,
+                    "priority": 1,
+                    "type": 0,
+                    "publication_name": "Publication Title"
+                },
+                ...
+            ]
         }
+
+    Example Error Response (HTTP 400):
+
+        {
+            "success": false,
+            "message": "Validation error: 'collection_id' must be a positive integer.",
+            "data": null
 
     Status Codes:
 
@@ -986,42 +1085,58 @@ def list_publication_collections(project):
 
     Returns:
 
-        JSON: A list of all publication collection objects associated
-        with the given project, an empty list if there are none,
-        or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a list of publication collection objects; `null`
+      on error.
 
     Example Request:
 
-        GET /<project>/publication_collection/list/
+        GET /projectname/publication_collection/list/
 
-    Example Response (Success):
-
-        [
-            {
-                "id": 1,
-                "name": "Collection Title",
-                "published": 1,
-                "date_created": "2023-05-12T12:34:56",
-                "date_modified": "2023-06-01T08:22:11",
-                "date_published_externally": null,
-                "deleted": 0,
-                "legacy_id": null,
-                "project_id": 101,
-                "publication_collection_title_id": 55,
-                "publication_collection_introduction_id": 75,
-                "name_translation_id": null,
-                "collection_title_filename": "title_file.xml",
-                "collection_intro_filename": "intro_file.xml",
-                "collection_title_published": 1,
-                "collection_intro_published": 1
-            },
-            ...
-        ]
-
-    Example Response (Error):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "No such project exists."
+            "success": true,
+            "message": "Retrieved # records.",
+            "data": [
+                {
+                    "id": 1,
+                    "name": "Collection Title",
+                    "published": 1,
+                    "date_created": "2023-05-12T12:34:56",
+                    "date_modified": "2023-06-01T08:22:11",
+                    "date_published_externally": null,
+                    "deleted": 0,
+                    "legacy_id": null,
+                    "project_id": 101,
+                    "publication_collection_title_id": 55,
+                    "publication_collection_introduction_id": 75,
+                    "name_translation_id": null,
+                    "collection_title_filename": "title_file.xml",
+                    "collection_intro_filename": "intro_file.xml",
+                    "collection_title_published": 1,
+                    "collection_intro_published": 1
+                },
+                ...
+            ]
+        }
+
+    Example Error Response (HTTP 400):
+
+        {
+            "success": false,
+            "message": "Validation error: 'project' does not exist.",
+            "data": null
         }
 
     Status Codes:
@@ -1104,8 +1219,19 @@ def new_publication_collection(project):
 
     Returns:
 
-        JSON: A success message and the inserted publication collection
-        row, or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the inserted publication
+      collection data; `null` on error.
 
     Example Request:
 
@@ -1116,22 +1242,33 @@ def new_publication_collection(project):
             "published": 1
         }
 
-    Example Response (Success):
+    Example Success Response (HTTP 201):
 
         {
-            "msg": "Publication collection created successfully.",
-            "row": {
-                "id": 789,
-                "name": "My New Collection",
+            "success": true,
+            "message": "Publication collection created.",
+            "data": {
+                "id": 1,
+                "publication_collection_introduction_id": null,
+                "publication_collection_title_id": null,
+                "project_id": 101,
+                "date_created": "2023-05-12T12:34:56",
+                "date_modified": null,
+                "date_published_externally": null,
+                "deleted": 0,
                 "published": 1,
-                ...
+                "name": "My New Collection",
+                "legacy_id": null,
+                "name_translation_id": null
             }
         }
 
-    Example Response (Error):
+    Example Error Response (HTTP 400):
 
         {
-            "msg": "Field 'published' must be an integer with value 0, 1 or 2."
+            "success": false,
+            "message": "Validation error: 'name' required.",
+            "data": null
         }
 
     Status Codes:
@@ -1233,43 +1370,59 @@ def list_publications(project, collection_id, order_by="id"):
 
     Returns:
 
-        JSON: A list of publication objects in the specified collection, an
-        empty list if there are no publications, or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a list of publication objects; `null` on error.
 
     Example Request:
 
         GET /projectname/publication_collection/123/publications/
         GET /projectname/publication_collection/123/publications/name/
 
-    Example Response (Success):
-
-        [
-            {
-                "id": 1,
-                "publication_collection_id": 123,
-                "publication_comment_id": 5487,
-                "date_created": "2023-05-12T12:34:56",
-                "date_modified": "2023-06-01T08:22:11",
-                "date_published_externally": null,
-                "deleted": 0,
-                "published": 1,
-                "legacy_id": null,
-                "published_by": null,
-                "original_filename": "/path/to/file.xml",
-                "name": "Publication Title",
-                "genre": "non-fiction",
-                "publication_group_id": null,
-                "original_publication_date": "1854",
-                "zts_id": null,
-                "language": "en"
-            },
-            ...
-        ]
-
-    Example Response (Error):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "Invalid collection_id, does not exist."
+            "success": true,
+            "message": "Retrieved # records.",
+            "data": [
+                {
+                    "id": 1,
+                    "publication_collection_id": 123,
+                    "publication_comment_id": 5487,
+                    "date_created": "2023-05-12T12:34:56",
+                    "date_modified": "2023-06-01T08:22:11",
+                    "date_published_externally": null,
+                    "deleted": 0,
+                    "published": 1,
+                    "legacy_id": null,
+                    "published_by": null,
+                    "original_filename": "/path/to/file.xml",
+                    "name": "Publication Title",
+                    "genre": "non-fiction",
+                    "publication_group_id": null,
+                    "original_publication_date": "1854",
+                    "zts_id": null,
+                    "language": "en"
+                },
+                ...
+            ]
+        }
+
+    Example Error Response (HTTP 400):
+
+        {
+            "success": false,
+            "message": "Validation error: 'collection_id' must be a positive integer.",
+            "data": null
         }
 
     Status Codes:
@@ -1358,7 +1511,19 @@ def new_publication(project, collection_id):
 
     Returns:
 
-        JSON: A success message with the inserted row or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the inserted publication
+      data; `null` on error.
 
     Example Request:
 
@@ -1366,25 +1531,43 @@ def new_publication(project, collection_id):
         Body:
         {
             "name": "New Publication",
-            "published": 1
+            "original_filename": "/path/to/file.xml",
+            "original_publication_date": "1854",
+            "language": "en"
         }
 
-    Example Response (Success):
+    Example Success Response (HTTP 201):
 
         {
-            "msg": "Publication created successfully.",
-            "row": {
-                "id": 789,
-                "name": "New Publication",
+            "success": true,
+            "message": "Publication created.",
+            "data":  {
+                "id": 1,
+                "publication_collection_id": 123,
+                "publication_comment_id": null,
+                "date_created": "2023-05-12T12:34:56",
+                "date_modified": null,
+                "date_published_externally": null,
+                "deleted": 0,
                 "published": 1,
-                ...
+                "legacy_id": null,
+                "published_by": null,
+                "original_filename": "/path/to/file.xml",
+                "name": "New Publication",
+                "genre": null,
+                "publication_group_id": null,
+                "original_publication_date": "1854",
+                "zts_id": null,
+                "language": "en"
             }
         }
 
-    Example Response (Error):
+    Example Error Response (HTTP 400):
 
         {
-            "msg": "Field 'published' must be an integer with value 0, 1 or 2."
+            "success": false,
+            "message": "Validation error: 'collection_id' must be a positive integer.",
+            "data": null
         }
 
     Status Codes:

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -660,29 +660,30 @@ def list_publications(project, collection_id, order_by="id"):
 
     try:
         with db_engine.connect() as connection:
-            # Check for publication_collection existence
-            select_coll_stmt = (
-                select(collection_table.c.project_id)
-                .where(collection_table.c.id == collection_id)
-            )
-            result = connection.execute(select_coll_stmt).first()
+            with connection.begin():
+                # Check for publication_collection existence
+                select_coll_stmt = (
+                    select(collection_table.c.project_id)
+                    .where(collection_table.c.id == collection_id)
+                )
+                result = connection.execute(select_coll_stmt).first()
 
-            if not result:
-                return jsonify({"msg": "Invalid collection_id, does not exist."}), 400
+                if not result:
+                    return jsonify({"msg": "Invalid collection_id, does not exist."}), 400
 
-            # Check that the publication collection belongs to the provided project
-            if project_id != result[0]:
-                return jsonify({"msg": f"The publication collection with id '{collection_id}' does not belong to project '{project}'."}), 400
+                # Check that the publication collection belongs to the provided project
+                if project_id != result[0]:
+                    return jsonify({"msg": f"The publication collection with id '{collection_id}' does not belong to project '{project}'."}), 400
 
-            # Proceed to selecting the publications
-            select_pub_stmt = (
-                select(publication_table)
-                .where(publication_table.c.publication_collection_id == collection_id)
-                .order_by(str(order_by))
-            )
-            rows = connection.execute(select_pub_stmt).fetchall()
-            result = [row._asdict() for row in rows]
-            return jsonify(result)
+                # Proceed to selecting the publications
+                select_pub_stmt = (
+                    select(publication_table)
+                    .where(publication_table.c.publication_collection_id == collection_id)
+                    .order_by(str(order_by))
+                )
+                rows = connection.execute(select_pub_stmt).fetchall()
+                result = [row._asdict() for row in rows]
+                return jsonify(result)
 
     except Exception as e:
         return jsonify({"msg": "Failed to retrieve publications.",

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -145,6 +145,11 @@ def list_facsimile_collections(project):
     """
     project_id = get_project_id_from_name(project)
     connection = db_engine.connect()
+    # Select all publication_collection objects that are linked to the
+    # project through publication_facsimile -> publication ->
+    # publication_collection
+    # AND all publication_collection objects that are orphans, i.e. they
+    # are not linked to any publication_collection
     statement = """ select * from publication_facsimile_collection where deleted != 1 AND (
                     id in
                     (

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -49,12 +49,12 @@ def create_facsimile_collection(project):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the inserted facsimile
+    - `data`: On success, an object containing the inserted facsimile
        collection data; `null` on error.
 
     Example Request:
@@ -215,12 +215,12 @@ def edit_facsimile_collection(project, collection_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the updated facsimile
+    - `data`: On success, an object containing the updated facsimile
        collection data; `null` on error.
 
     Example Request:
@@ -377,13 +377,13 @@ def list_facsimile_collections(project, order_by="id", direction="desc"):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": array of objects or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a list of facsimile collection objects;
-       `null` on error.
+    - `data`: On success, an array of facsimile collection objects; `null`
+       on error.
 
     Example Request:
 
@@ -590,13 +590,13 @@ def link_facsimile_collection_to_publication(project, collection_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the inserted facsimile
-       data; `null` on error.
+    - `data`: On success, an object containing the inserted facsimile data;
+      `null` on error.
 
     Example Request:
 
@@ -774,12 +774,12 @@ def edit_facsimile(project):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the updated facsimile data;
+    - `data`: On success, an object containing the updated facsimile data;
       `null` on error.
 
     Example Request:
@@ -947,12 +947,12 @@ def list_facsimile_collection_links(project, collection_id, order_by="id", direc
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": array of objects or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a list of facsimile objects; `null` on error.
+    - `data`: On success, an array of facsimile objects; `null` on error.
 
     Example Request:
 
@@ -1075,12 +1075,12 @@ def list_publication_collections(project):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": array of objects or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a list of publication collection objects; `null`
+    - `data`: On success, an array of publication collection objects; `null`
       on error.
 
     Example Request:
@@ -1209,12 +1209,12 @@ def new_publication_collection(project):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the inserted publication
+    - `data`: On success, an object containing the inserted publication
       collection data; `null` on error.
 
     Example Request:
@@ -1356,12 +1356,12 @@ def list_publications(project, collection_id, order_by="id"):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": array of objects or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a list of publication objects; `null` on error.
+    - `data`: On success, an array of publication objects; `null` on error.
 
     Example Request:
 
@@ -1497,12 +1497,12 @@ def new_publication(project, collection_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the inserted publication
+    - `data`: On success, an object containing the inserted publication
       data; `null` on error.
 
     Example Request:

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -460,7 +460,7 @@ def list_facsimile_collections(project):
                 publication_collection.c.deleted < 1
             )
 
-            # Subquery to get publication IDs linked to all 
+            # Subquery to get publication IDs linked to all
             # publication_collections
             all_publication_subq = select(publication.c.id).where(
                 publication.c.publication_collection_id.in_(all_pub_coll_subq)

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -482,7 +482,7 @@ def list_facsimile_collections(project):
                     )
                 )
             )
-            result = connection.execute(stmt).fetchall()
+            rows = connection.execute(stmt).fetchall()
             result = [row._asdict() for row in rows]
             return jsonify(result)
 

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -295,7 +295,7 @@ def edit_facsimile_collection(project, collection_id):
                 values[field] = request_data[field]
 
     if not values:
-        return create_error_response(f"Validation error: no valid fields provided to update.")
+        return create_error_response("Validation error: no valid fields provided to update.")
 
     # Add date_modified
     values["date_modified"] = datetime.now()
@@ -639,7 +639,7 @@ def link_facsimile_collection_to_publication(project, collection_id):
             values[field] = request_data[field]
 
     if not values:
-        return create_error_response(f"Validation error: no valid fields provided to update.")
+        return create_error_response("Validation error: no valid fields provided to update.")
 
     # Set default values for "page_nr", "section_id", "priority", "type"
     for field in ["page_nr", "section_id", "priority", "type"]:
@@ -806,7 +806,7 @@ def edit_facsimile(project):
             values[field] = request_data[field]
 
     if not values:
-        return create_error_response(f"Validation error: no valid fields provided to update.")
+        return create_error_response("Validation error: no valid fields provided to update.")
 
     # Add date_modified
     values["date_modified"] = datetime.now()

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -690,7 +690,7 @@ def link_facsimile_collection_to_publication(project, collection_id):
                     }), 201
 
                 except Exception as e:
-                    return jsonify({"msg": f"Failed to create new publication facsimile.",
+                    return jsonify({"msg": "Failed to create new publication facsimile.",
                                     "reason": str(e)}), 400
 
     except Exception as e:

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -977,28 +977,6 @@ def list_facsimile_collection_links(project, collection_id, order_by="id", direc
                         "reason": str(e)}), 500
 
 
-@collection_tools.route("/<project>/facsimile_publication/delete/<f_pub_id>", methods=["DELETE"])
-@project_permission_required
-def delete_facsimile_collection_link(project, f_pub_id):
-    """
-    Delete the specified publication facsimile.
-    """
-    connection = db_engine.connect()
-    publication_facsimile = get_table("publication_facsimile")
-    values = {
-        'deleted': 1,
-        "date_modified": datetime.now()
-    }
-    with connection.begin():
-        update = publication_facsimile.update().where(publication_facsimile.c.id == int(f_pub_id)).values(**values)
-        connection.execute(update)
-    connection.close()
-    result = {
-        "msg": "Deleted publication_facsimile"
-    }
-    return jsonify(result), 200
-
-
 @collection_tools.route("/<project>/publication_collection/list/")
 @project_permission_required
 def list_publication_collections(project):

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -375,11 +375,14 @@ def list_publication_collections(project):
 
     URL Path Parameter:
 
-    - project (str, required): The name of the project to retrieve publication collections for.
+    - project (str, required): The name of the project to retrieve
+      publication collections for.
 
     Returns:
 
-        JSON: A list of all publication collection objects associated with the given project, or an error message.
+        JSON: A list of all publication collection objects associated
+        with the given project, an empty list if there are none,
+        or an error message.
 
     Example Request:
 
@@ -405,7 +408,8 @@ def list_publication_collections(project):
                 "collection_intro_filename": "intro_file.xml",
                 "collection_title_published": 1,
                 "collection_intro_published": 1
-            }
+            },
+            ...
         ]
 
     Example Response (Error):
@@ -486,12 +490,12 @@ def new_publication_collection(project):
     - name (str, required): The name/title of the publication collection.
       Cannot be empty.
     - published (int): The publication status of the collection. Must be an
-      integer with values 0, 1 or 2. Default value is 1.
+      integer with value 0, 1 or 2. Default value is 1.
 
     Returns:
 
-        JSON: A success message with the id of the inserted publication
-        collection, or an error message.
+        JSON: A success message and the inserted publication collection
+        row, or an error message.
 
     Example Request:
 
@@ -861,8 +865,8 @@ def new_publication(project, collection_id):
                 if project_id != result[0]:
                     return jsonify({"msg": f"The publication collection with id '{collection_id}' does not belong to project '{project}'."}), 400
 
-                # If a publication_comment_id was provided, check that it exists and is
-                # not deleted
+                # If a publication_comment_id was provided, check that it
+                # exists and is not deleted
                 if "publication_comment_id" in values:
                     comment_table = get_table("publication_comment")
                     select_com_stmt = (

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -371,7 +371,7 @@ def delete_facsimile_collection_link(project, f_pub_id):
 @project_permission_required
 def list_publication_collections(project):
     """
-    List all publication collections for a given project.
+    List all (non-deleted) publication collections for a given project.
 
     URL Path Parameter:
 
@@ -453,6 +453,7 @@ def list_publication_collections(project):
             ON pci.id = pc.publication_collection_introduction_id
         WHERE
             pc.project_id = :project_id
+            AND pc.deleted < 1
         ORDER BY
             pc.id
     """
@@ -604,7 +605,8 @@ def new_publication_collection(project):
 @project_permission_required
 def list_publications(project, collection_id, order_by="id"):
     """
-    List all publications within a specific publication collection for a given project.
+    List all (non-deleted) publications within a specific publication
+    collection for a given project.
 
     URL Path Parameters:
 
@@ -686,6 +688,7 @@ def list_publications(project, collection_id, order_by="id"):
                 select_coll_stmt = (
                     select(collection_table.c.project_id)
                     .where(collection_table.c.id == collection_id)
+                    .where(collection_table.c.deleted < 1)
                 )
                 result = connection.execute(select_coll_stmt).first()
 
@@ -700,6 +703,7 @@ def list_publications(project, collection_id, order_by="id"):
                 select_pub_stmt = (
                     select(publication_table)
                     .where(publication_table.c.publication_collection_id == collection_id)
+                    .where(publication_table.c.deleted < 1)
                     .order_by(publication_table.c[order_by])
                 )
                 rows = connection.execute(select_pub_stmt).fetchall()

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -161,8 +161,7 @@ def create_facsimile_collection(project):
                     .values(**values)
                     .returning(*facs_coll_table.c)  # Return the inserted row
                 )
-                result = connection.execute(stmt)
-                inserted_row = result.fetchone()  # Fetch the inserted row
+                inserted_row = connection.execute(stmt).first()
 
                 if inserted_row is None:
                     return create_error_response("Insertion failed: no row returned.", 500)
@@ -394,7 +393,7 @@ def list_facsimile_collections(project, order_by="id", direction="desc"):
 
         {
             "success": true,
-            "message": "Retrieved # records.",
+            "message": "Retrieved # facsimile collections.",
             "data": [
                 {
                     "id": 123,
@@ -547,7 +546,7 @@ def list_facsimile_collections(project, order_by="id", direction="desc"):
 
             rows = connection.execute(stmt).fetchall()
             return create_success_response(
-                message=f"Retrieved {len(rows)} records.",
+                message=f"Retrieved {len(rows)} facsimile collections.",
                 data=[row._asdict() for row in rows]
             )
 
@@ -963,7 +962,7 @@ def list_facsimile_collection_links(project, collection_id, order_by="id", direc
 
         {
             "success": true,
-            "message": "Retrieved # records.",
+            "message": "Retrieved # publication facsimiles.",
             "data": [
                 {
                     "id": 456,
@@ -1048,7 +1047,7 @@ def list_facsimile_collection_links(project, collection_id, order_by="id", direc
             rows = connection.execute(stmt).fetchall()
 
             return create_success_response(
-                message=f"Retrieved {len(rows)} records.",
+                message=f"Retrieved {len(rows)} publication facsimiles.",
                 data=[row._asdict() for row in rows]
             )
 
@@ -1092,7 +1091,7 @@ def list_publication_collections(project):
 
         {
             "success": true,
-            "message": "Retrieved # records.",
+            "message": "Retrieved # publication collections.",
             "data": [
                 {
                     "id": 1,
@@ -1176,7 +1175,7 @@ def list_publication_collections(project):
             ).fetchall()
 
             return create_success_response(
-                message=f"Retrieved {len(rows)} records.",
+                message=f"Retrieved {len(rows)} publication collections.",
                 data=[row._asdict() for row in rows]
             )
 
@@ -1373,7 +1372,7 @@ def list_publications(project, collection_id, order_by="id"):
 
         {
             "success": true,
-            "message": "Retrieved # records.",
+            "message": "Retrieved # publications.",
             "data": [
                 {
                     "id": 1,
@@ -1453,7 +1452,7 @@ def list_publications(project, collection_id, order_by="id"):
                 rows = connection.execute(select_pub_stmt).fetchall()
 
                 return create_success_response(
-                    message=f"Retrieved {len(rows)} records.",
+                    message=f"Retrieved {len(rows)} publications.",
                     data=[row._asdict() for row in rows]
                 )
 

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -613,7 +613,7 @@ def list_publications(project, collection_id, order_by="id"):
     - collection_id (int, required): The id of the publication collection
       to retrieve publications from.
     - order_by (str, optional): The column by which to order the publications.
-      Must be one of "id", "name", "original_filename", "genre", "language".
+      For example "id", "name", "original_filename" or "date_modified".
       Defaults to "id".
 
     Returns:
@@ -673,13 +673,11 @@ def list_publications(project, collection_id, order_by="id"):
     if not collection_id or collection_id < 1:
         return jsonify({"msg": "Invalid collection_id, must be an integer."}), 400
 
-    # Verify that order_by is an allowed column name
-    allowed_order_columns = ["id", "name", "original_filename", "genre", "language"]
-    if order_by not in allowed_order_columns:
-        return jsonify({"msg": "Invalid order_by field."}), 400
-
     collection_table = get_table("publication_collection")
     publication_table = get_table("publication")
+
+    if order_by not in publication_table.c:
+        return jsonify({"msg": "Invalid order_by field."}), 400
 
     try:
         with db_engine.connect() as connection:
@@ -702,7 +700,7 @@ def list_publications(project, collection_id, order_by="id"):
                 select_pub_stmt = (
                     select(publication_table)
                     .where(publication_table.c.publication_collection_id == collection_id)
-                    .order_by(str(order_by))
+                    .order_by(publication_table.c[order_by])
                 )
                 rows = connection.execute(select_pub_stmt).fetchall()
                 result = [row._asdict() for row in rows]

--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -374,15 +374,19 @@ def list_publication_collections(project):
     List all publication collections for a given project.
 
     URL Path Parameter:
+
     - project (str, required): The name of the project to retrieve publication collections for.
 
     Returns:
+
         JSON: A list of all publication collection objects associated with the given project, or an error message.
 
     Example Request:
+
         GET /<project>/publication_collection/list/
 
     Example Response (Success):
+
         [
             {
                 "id": 1,
@@ -405,14 +409,17 @@ def list_publication_collections(project):
         ]
 
     Example Response (Error):
+
         {
             "msg": "No such project exists."
         }
 
     Status Codes:
-        200 - OK: The request was successful, and the publication collections are returned.
-        400 - Bad Request: The project does not exist.
-        500 - Internal Server Error: Failed to retrieve the publication collections.
+
+    - 200 - OK: The request was successful, and the publication collections
+            are returned.
+    - 400 - Bad Request: The project does not exist.
+    - 500 - Internal Server Error: Database query or execution failed.
     """
     project_id = get_project_id_from_name(project)
     if not project_id:
@@ -469,19 +476,24 @@ def new_publication_collection(project):
     """
     Create a new publication collection in the specified project.
 
-    Parameters:
+    URL Path Parameters:
+
     - project (str): The name of the project.
 
-    POST data parameters in JSON format:
-    - name (str, required): The name/title of the publication collection. Must be non-empty.
+    POST Data Parameters in JSON Format:
+
+    - name (str, required): The name/title of the publication collection.
+      Cannot be empty.
     - published (int): The publication status of the collection. Must be an
       integer with values 0, 1 or 2. Default value is 1.
 
     Returns:
-        JSON: A success message with the id of the inserted publication collection,
-        or an error message.
+
+        JSON: A success message with the id of the inserted publication
+        collection, or an error message.
 
     Example Request:
+
         POST /projectname/publication_collection/new/
         Body:
         {
@@ -490,6 +502,7 @@ def new_publication_collection(project):
         }
 
     Example Response (Success):
+
         {
             "msg": "Publication collection created successfully.",
             "row": {
@@ -501,15 +514,17 @@ def new_publication_collection(project):
         }
 
     Example Response (Error):
+
         {
             "msg": "Field 'published' must be an integer with value 0, 1 or 2."
         }
 
     Status Codes:
-        201 - Created: The publication collection was inserted successfully.
-        400 - Bad Request: Invalid project name, invalid field values, or no valid
-              fields provided for insertion.
-        500 - Internal Server Error: Database query or execution failed.
+
+    - 201 - Created: The publication collection was inserted successfully.
+    - 400 - Bad Request: Invalid project name, invalid field values, or no
+            valid fields provided for insertion.
+    - 500 - Internal Server Error: Database query or execution failed.
     """
     # Verify that project is valid
     project_id = get_project_id_from_name(project)
@@ -592,21 +607,27 @@ def list_publications(project, collection_id, order_by="id"):
     List all publications within a specific publication collection for a given project.
 
     URL Path Parameters:
-    - project (str, required): The name of the project for which to retrieve publications.
-    - collection_id (int, required): The id of the publication collection to retrieve
-      publications from.
-    - order_by (str, optional): The column by which to order the publications. Must be one
-      of "id", "name", "original_filename", "genre", "language". Defaults to "id".
+
+    - project (str, required): The name of the project for which to
+      retrieve publications.
+    - collection_id (int, required): The id of the publication collection
+      to retrieve publications from.
+    - order_by (str, optional): The column by which to order the publications.
+      Must be one of "id", "name", "original_filename", "genre", "language".
+      Defaults to "id".
 
     Returns:
-        JSON: A list of publication objects in the specified collection, an empty list
-        if there are no publications, or an error message.
+
+        JSON: A list of publication objects in the specified collection, an
+        empty list if there are no publications, or an error message.
 
     Example Request:
+
         GET /projectname/publication_collection/123/publications/
         GET /projectname/publication_collection/123/publications/name/
 
     Example Response (Success):
+
         [
             {
                 "id": 1,
@@ -631,14 +652,16 @@ def list_publications(project, collection_id, order_by="id"):
         ]
 
     Example Response (Error):
+
         {
             "msg": "Invalid collection_id, does not exist."
         }
 
     Status Codes:
-        200 - OK: The request was successful, and the publications are returned.
-        400 - Bad Request: The project name or collection_id is invalid.
-        500 - Internal Server Error: Failed to retrieve publications due to a server error.
+
+    - 200 - OK: The request was successful, and the publications are returned.
+    - 400 - Bad Request: The project name or collection_id is invalid.
+    - 500 - Internal Server Error: Database query or execution failed.
     """
     # Verify that project name is valid and get project_id
     project_id = get_project_id_from_name(project)
@@ -696,30 +719,34 @@ def new_publication(project, collection_id):
     """
     Create a new publication as part of the specified publication collection.
 
-    Parameters:
-    - project (str): The name of the project.
-    - collection_id (int): The id of the publication collection to which the new
-      publication will be added.
+    URL Path Parameters:
 
-    POST data parameters in JSON format:
+    - project (str): The name of the project.
+    - collection_id (int): The id of the publication collection to which
+      the new publication will be added.
+
+    POST Data Parameters in JSON Format:
+
     - name (str, required): The name/title of the publication. Cannot be empty.
-    - publication_comment_id (int, optional): id of the associated publication comment.
-      Must be a positive integer, and the comment must exist in the 'publication_comment'
-      table.
-    - published (int, optional): The publication status. Must be an integer with value 0,
-      1 or 2. Defaults to 1.
+    - publication_comment_id (int, optional): id of the associated
+      publication comment. Must be a positive integer, and the comment must
+      exist in the 'publication_comment' table.
+    - published (int, optional): The publication status. Must be an integer
+      with value 0, 1 or 2. Defaults to 1.
     - legacy_id (str, optional): Legacy id for the publication.
     - original_filename (str, optional): File path to the publication XML file.
     - genre (str, optional): The genre of the publication.
-    - original_publication_date (str, optional): Date when the publication was originally
-      published.
-    - language (str, optional): Language code (ISO 639-1) of the principal language of the
-      publication.
+    - original_publication_date (str, optional): Date when the publication
+      was originally published.
+    - language (str, optional): Language code (ISO 639-1) of the main
+      language of the publication.
 
     Returns:
+
         JSON: A success message with the inserted row or an error message.
 
     Example Request:
+
         POST /projectname/publication_collection/123/publications/new/
         Body:
         {
@@ -728,6 +755,7 @@ def new_publication(project, collection_id):
         }
 
     Example Response (Success):
+
         {
             "msg": "Publication created successfully.",
             "row": {
@@ -739,15 +767,17 @@ def new_publication(project, collection_id):
         }
 
     Example Response (Error):
+
         {
             "msg": "Field 'published' must be an integer with value 0, 1 or 2."
         }
 
     Status Codes:
-        201 - Created: The publication was inserted successfully.
-        400 - Bad Request: Invalid project name, collection id, field values,
-              or no data provided.
-        500 - Internal Server Error: Database query or execution failed.
+
+    - 201 - Created: The publication was inserted successfully.
+    - 400 - Bad Request: Invalid project name, collection id, field values,
+            or no data provided.
+    - 500 - Internal Server Error: Database query or execution failed.
     """
     # Verify that project name is valid and get project_id
     project_id = get_project_id_from_name(project)

--- a/sls_api/endpoints/tools/events.py
+++ b/sls_api/endpoints/tools/events.py
@@ -970,6 +970,7 @@ def list_translations(project, translation_id):
       `translation` table. Must be a valid integer.
 
     POST Data Parameters in JSON Format (optional):
+
     - table_name (str): Filter translations by a specific table name.
     - field_name (str): Filter translations by a specific field name.
     - language (str): Filter translations by a specific language.

--- a/sls_api/endpoints/tools/events.py
+++ b/sls_api/endpoints/tools/events.py
@@ -515,7 +515,8 @@ def edit_translation(project, translation_id):
 @project_permission_required
 def list_translations(project, translation_id):
     """
-    List all translations for a given translation_id with optional filters.
+    List all (non-deleted) translations for a given translation_id
+    with optional filters.
 
     URL Path Parameters:
 

--- a/sls_api/endpoints/tools/events.py
+++ b/sls_api/endpoints/tools/events.py
@@ -171,8 +171,8 @@ def edit_location(project, location_id):
 @project_permission_required
 def list_project_subjects(project, order_by="last_name", direction="asc"):
     """
-    List all (non-deleted) subjects for a specified project, with optional sorting
-    by subject table columns.
+    List all (non-deleted) subjects (persons) for a specified project,
+    with optional sorting by subject table columns.
 
     URL Path Parameters:
 
@@ -186,52 +186,69 @@ def list_project_subjects(project, order_by="last_name", direction="asc"):
 
     Returns:
 
-        JSON: A list of subject objects within the specified project,
-        an empty list if there are no subjects, or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a list of subject objects; `null` on error.
 
     Example Request:
 
         GET /projectname/subjects/list/
         GET /projectname/subjects/list/last_name/asc/
 
-    Example Response (Success):
-
-        [
-            {
-                "id": 1,
-                "date_created": "2023-05-12T12:34:56",
-                "date_modified": "2023-06-01T08:22:11",
-                "deleted": 0,
-                "type": "Historical person",
-                "first_name": "John",
-                "last_name": "Doe",
-                "place_of_birth": "Fantasytown",
-                "occupation": "Doctor",
-                "preposition": "von",
-                "full_name": "John von Doe",
-                "description": "a brief description about the person.",
-                "legacy_id": "pe1",
-                "date_born": "1870",
-                "date_deceased": "1915",
-                "project_id": 123,
-                "source": "Encyclopaedia Britannica",
-                "alias": "JD",
-                "previous_last_name": "Crow",
-                "translation_id": 4287
-            },
-            ...
-        ]
-
-    Example Response (Error):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "Invalid project name."
+            "success": true,
+            "message": "Retrieved # records.",
+            "data": [
+                {
+                    "id": 1,
+                    "date_created": "2023-05-12T12:34:56",
+                    "date_modified": "2023-06-01T08:22:11",
+                    "deleted": 0,
+                    "type": "Historical person",
+                    "first_name": "John",
+                    "last_name": "Doe",
+                    "place_of_birth": "Fantasytown",
+                    "occupation": "Doctor",
+                    "preposition": "von",
+                    "full_name": "John von Doe",
+                    "description": "a brief description about the person.",
+                    "legacy_id": "pe1",
+                    "date_born": "1870",
+                    "date_deceased": "1915",
+                    "project_id": 123,
+                    "source": "Encyclopaedia Britannica",
+                    "alias": "JD",
+                    "previous_last_name": "Crow",
+                    "translation_id": 4287
+                },
+                ...
+            ]
+        }
+
+    Example Error Response (HTTP 400):
+
+        {
+            "success": false,
+            "message": "Validation error: 'project' does not exist.",
+            "data": null
         }
 
     Status Codes:
 
     - 200 - OK: The request was successful, and the subjects are returned.
-    - 400 - Bad Request: The project name, order_by field, or sort direction is invalid.
+    - 400 - Bad Request: The project name, order_by field, or sort direction
+            is invalid.
     - 500 - Internal Server Error: Database query or execution failed.
     """
     # Verify that project name is valid and get project_id
@@ -309,23 +326,34 @@ def add_new_subject(project):
     - last_name (str): The last name of the person.
     - place_of_birth (str): The place where the person was born.
     - occupation (str): The person's occupation.
-    - preposition (str): Prepositional or nobiliary particle used in the surname of
-      the person.
+    - preposition (str): Prepositional or nobiliary particle used in the
+      surname of the person.
     - full_name (str): The full name of the person.
     - description (str): A brief description of the person.
     - legacy_id (str): An identifier from a legacy system.
-    - date_born (str, optional): The birth date or year of the person (max length
-      30 characters), in YYYY-MM-DD or YYYY format.
-    - date_deceased (str, optional): The date of death of the person (max length
-      30 characters), in YYYY-MM-DD or YYYY format.
+    - date_born (str, optional): The birth date or year of the person
+      (max length 30 characters), in YYYY-MM-DD or YYYY format.
+    - date_deceased (str, optional): The date of death of the person
+      (max length 30 characters), in YYYY-MM-DD or YYYY format.
     - source (str): The source of the information.
     - alias (str, optional): An alias for the person.
     - previous_last_name (str, optional): The person's previous last name.
 
     Returns:
 
-        JSON: A message indicating the success of the operation, along with the
-        created subject object, or an error message if the operation fails.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the inserted subject
+      data; `null` on error.
 
     Example Request:
 
@@ -347,11 +375,12 @@ def add_new_subject(project):
             "previous_last_name": "Smith"
         }
 
-    Example Response (Success):
+    Example Success Response (HTTP 201):
 
         {
-            "msg": "Subject with ID 123 created successfully.",
-            "row": {
+            "success": true,
+            "message": "Person record created.",
+            "data": {
                 "id": 123,
                 "date_created": "2023-05-12T12:34:56",
                 "date_modified": "2023-06-01T08:22:11",
@@ -375,10 +404,12 @@ def add_new_subject(project):
             }
         }
 
-    Example Response (Error):
+    Example Error Response (HTTP 400):
 
         {
-            "msg": "Invalid project name."
+            "success": false,
+            "message": "Validation error: 'date_born' must be 30 or less characters in length.",
+            "data": null
         }
 
     Status Codes:
@@ -484,29 +515,41 @@ def edit_subject(project, subject_id):
 
     POST Data Parameters in JSON Format (at least one required):
 
-    - deleted (int): Indicates if the subject is deleted (0 for no, 1 for yes).
+    - deleted (int): Indicates if the subject is deleted (0 for no,
+      1 for yes).
     - type (str): The type of person.
     - first_name (str): The first name of the person.
     - last_name (str): The last name of the person.
     - place_of_birth (str): The place where the person was born.
     - occupation (str): The person's occupation.
-    - preposition (str): Prepositional or nobiliary particle used in the surname
-      of the person.
+    - preposition (str): Prepositional or nobiliary particle used in the
+      surname of the person.
     - full_name (str): The full name of the person.
     - description (str): A brief description of the person.
     - legacy_id (str): An identifier from a legacy system.
-    - date_born (str, optional): The birth date or year of the person (max length
-      30 characters), in YYYY-MM-DD or YYYY format.
-    - date_deceased (str, optional): The date of death of the person (max length
-      30 characters), in YYYY-MM-DD or YYYY format.
+    - date_born (str, optional): The birth date or year of the person
+      (max length 30 characters), in YYYY-MM-DD or YYYY format.
+    - date_deceased (str, optional): The date of death of the person
+      (max length 30 characters), in YYYY-MM-DD or YYYY format.
     - source (str): The source of the information.
     - alias (str, optional): An alias for the person.
     - previous_last_name (str, optional): The person's previous last name.
 
     Returns:
 
-        JSON: A message indicating the success of the operation, along with the updated
-        subject object, or an error message if the operation fails.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the updated subject
+      data; `null` on error.
 
     Example Request:
 
@@ -529,11 +572,12 @@ def edit_subject(project, subject_id):
             "deleted": 0
         }
 
-    Example Response (Success):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "Updated subject with ID 123 successfully.",
-            "row": {
+            "success": true,
+            "message": "Person record updated.",
+            "data": {
                 "id": 123,
                 "date_created": "2023-05-12T12:34:56",
                 "date_modified": "2024-01-01T09:00:00",
@@ -557,10 +601,12 @@ def edit_subject(project, subject_id):
             }
         }
 
-    Example Response (Error):
+    Example Error Response (HTTP 400):
 
         {
-            "msg": "Invalid project name."
+            "success": false,
+            "message": "Validation error: 'subject_id' must be a positive integer.",
+            "data": null
         }
 
     Status Codes:
@@ -671,22 +717,80 @@ def add_new_translation(project):
 
     POST Data Parameters in JSON Format:
 
-    - table_name (str, required): name of the table containing the record to be
-      translated.
-    - field_name (str, required): name of the field to be translated (if applicable).
+    - table_name (str, required): name of the table containing the record
+      to be translated.
+    - field_name (str, required): name of the field to be translated (if
+      applicable).
     - text (str, required): the translated text.
-    - language (str, required): the language code for the translation (ISO 639-1).
-    - translation_id (int): the ID of an existing translation record in the
-      `translation` table. Required if you intend to add a translation in a new
-      language to an entry that already has one or more translations.
+    - language (str, required): the language code for the translation
+      (ISO 639-1).
+    - translation_id (int): the ID of an existing translation record in
+      the `translation` table. Required if you intend to add a translation
+      in a new language to an entry that already has one or more
+      translations.
     - parent_id (int): the ID of the record in the `table_name` table.
-    - parent_translation_field (str): the name of the field holding the translation_id
-      (defaults to 'translation_id').
+    - parent_translation_field (str): the name of the field holding the
+      translation_id (defaults to 'translation_id').
     - neutral_text (str): the base text before translation.
+
+    Returns:
+
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the inserted translation
+      text object; `null` on error.
+
+    Example Request:
+
+        POST /projectname/translation/new/
+        Body:
+        {
+            "table_name": "subject",
+            "field_name": "description",
+            "text": "a description of the person",
+            "language": "en",
+            "parent_id": 958,
+            "neutral_text": "en beskrivning av personen"
+        }
+
+    Example Success Response (HTTP 201):
+
+        {
+            "success": true,
+            "message": "Translation created.",
+            "data": {
+                "id": 123,
+                "translation_id": 7387,
+                "language": "en",
+                "text": "a description of the person",
+                "field_name": "description",
+                "table_name": "subject",
+                "date_created": "2023-05-12T12:34:56",
+                "date_modified": null,
+                "deleted": 0
+            }
+        }
+
+    Example Error Response (HTTP 400):
+
+        {
+            "success": false,
+            "message": "Validation error: 'text' and 'language' required.",
+            "data": null
+        }
 
     Return Codes:
 
-    - 201 - OK: Created new translation.
+    - 201 - Created: Successfully created new translation.
     - 400 - Bad Request: Invalid input.
     - 500 - Internal Server Error: Database query or execution failed.
     """
@@ -817,29 +921,85 @@ def edit_translation(project, translation_id):
     URL Path Parameters:
 
     - project (str, required): The name of the project.
-    - translation_id (int, required): The unique identifier of the translation to be
-      updated.
+    - translation_id (int, required): The unique identifier of the
+      translation object to be updated.
 
     POST Data Parameters in JSON Format (at least one required):
 
-    - translation_text_id (int): ID of the translation object in the
-      `translation_text` table.
+    - translation_text_id (int, recommended): ID of the translation text
+      object in the `translation_text` table.
     - table_name (str): name of the table being translated.
     - field_name (str): name of the field being translated.
     - text (str) the translation text.
     - language (str): language code of the translation (ISO 639-1).
     - deleted (int): flag to mark as deleted (0 for no and 1 for yes).
 
-    If translation_text_id is omitted, an attempt to find the translation object
-    which is to be updated is made based on translation_id, table_name, field_name
-    and language. If that fails, a new tranlation object will be created.
+    If translation_text_id is omitted, an attempt to find the translation
+    object which is to be updated is made based on translation_id,
+    table_name, field_name and language. If that fails, a new translation
+    object will be created.
+
+    In practice, it's always recommended to provide translation_text_id in
+    requests to this endpoint. To create a new translation, the
+    add_new_translation() endpoint should be used.
+
+    Returns:
+
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the updated translation
+      text object; `null` on error.
+
+    Example Request:
+
+        POST /projectname/translations/123/edit/
+        Body:
+        {
+            "translation_text_id": 456,
+            "text": "an edited translated text"
+        }
+
+    Example Success Response (HTTP 200):
+
+        {
+            "success": true,
+            "message": "Translation text updated.",
+            "data": {
+                "id": 456,
+                "translation_id": 123,
+                "language": "en",
+                "text": "an edited translated text",
+                "field_name": "description",
+                "table_name": "subject",
+                "date_created": "2023-05-12T12:34:56",
+                "date_modified": "2023-10-22T14:17:02",
+                "deleted": 0
+            }
+        }
+
+    Example Error Response (HTTP 400):
+
+        {
+            "success": false,
+            "message": "Validation error: 'translation_text_id' must be a positive integer.",
+            "data": null
+        }
 
     Response Codes:
 
-    - 201: New translation created.
-    - 200: Existing translation updated.
-    - 400: Invalid input.
-    - 500: Server error.
+    - 201 - Created: Successfully created new translation text.
+    - 200 - OK: Existing translation text updated.
+    - 400 - Bad Request: Invalid input.
+    - 500 - Internal Server Error: Database query or execution failed.
     """
     # Verify that project name is valid and get project_id
     project_id = get_project_id_from_name(project)
@@ -889,12 +1049,13 @@ def edit_translation(project, translation_id):
 
     translation_text_id = request_data.get("translation_text_id")
     if translation_text_id is None:
-        # Attempt to get the id of the record in translation_text based on translation id,
-        # table name, field name and language in the data
+        # Attempt to get the id of the record in translation_text based on
+        # translation id, table name, field name and language in the data
         translation_text_id = get_translation_text_id(translation_id,
                                                       values.get("table_name"),
                                                       values.get("field_name"),
                                                       values.get("language"))
+
     try:
         with db_engine.connect() as connection:
             with connection.begin():
@@ -986,36 +1147,57 @@ def list_translations(project, translation_id):
 
     Returns:
 
-        JSON: A list of translation records or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a list of translation text objects; `null` on
+      error.
 
     Example Request:
 
         POST /projectname/translations/1/list/
         Body:
         {
-            "table_name": "subject",
-            "field_name": "description",
-            "language": "en",
-            "translation_text_id": 123
+            "language": "en"
         }
 
-    Example Response:
+    Example Success Response (HTTP 200):
 
-        [
-            {
-                "translation_text_id": 123,
-                "translation_id": 1,
-                "language": "en",
-                "text": "Some description in English",
-                "field_name": "description",
-                "table_name": "subject"
-            },
-            ...
-        ]
+        {
+            "success": true,
+            "message": "Retrieved # records.",
+            "data": [
+                {
+                    "translation_text_id": 123,
+                    "translation_id": 1,
+                    "language": "en",
+                    "text": "Some description in English",
+                    "field_name": "description",
+                    "table_name": "subject"
+                },
+                ...
+            ]
+        }
+
+    Example Error Response (HTTP 400):
+
+        {
+            "success": false,
+            "message": "Validation error: 'translation_id' must be a positive integer.",
+            "data": null
+        }
 
     Status Codes:
 
-    - 200 - OK: Returns the list of translations.
+    - 200 - OK: Successfully retrieved the list of translation texts.
     - 400 - Bad Request: Invalid or missing translation_id.
     - 500 - Internal Server Error: Database query or execution failed.
     """

--- a/sls_api/endpoints/tools/events.py
+++ b/sls_api/endpoints/tools/events.py
@@ -921,11 +921,11 @@ def edit_translation(project, translation_id):
 
     - translation_text_id (int, recommended): ID of the translation text
       object in the `translation_text` table.
-    - table_name (str): name of the table being translated.
-    - field_name (str): name of the field being translated.
-    - text (str) the translation text.
-    - language (str): language code of the translation (ISO 639-1).
-    - deleted (int): flag to mark as deleted (0 for no and 1 for yes).
+    - table_name (str): Name of the table being translated.
+    - field_name (str): Name of the field being translated.
+    - text (str): The translation text.
+    - language (str): Language code of the translation (ISO 639-1).
+    - deleted (int): Soft delete flag. Must be an integer with value 0 or 1.
 
     If translation_text_id is omitted, an attempt to find the translation
     object which is to be updated is made based on translation_id,

--- a/sls_api/endpoints/tools/events.py
+++ b/sls_api/endpoints/tools/events.py
@@ -482,15 +482,11 @@ def add_new_subject(project):
                 inserted_row = connection.execute(stmt).first()
 
                 if inserted_row is None:
-                    # No row was returned; handle accordingly
                     return create_error_response("Insertion failed: no row returned.", 500)
-
-                # Convert the inserted_row to a dictionary for JSON serialization
-                inserted_row_dict = inserted_row._asdict()
 
                 return create_success_response(
                     message="Person record created.",
-                    data=inserted_row_dict,
+                    data=inserted_row._asdict(),
                     status_code=201
                 )
 
@@ -689,12 +685,9 @@ def edit_subject(project, subject_id):
                     # No row was returned: invalid subject_id or project name
                     return create_error_response("Update failed: no person record with the provided 'subject_id' found in project.")
 
-                # Convert the inserted row to a dict for JSON serialization
-                updated_row_dict = updated_row._asdict()
-
                 return create_success_response(
                     message="Person record updated.",
-                    data=updated_row_dict
+                    data=updated_row._asdict()
                 )
 
     except Exception as e:
@@ -901,12 +894,9 @@ def add_new_translation(project):
                 if inserted_row is None:
                     return create_error_response("Insertion failed: no row returned.", 500)
 
-                # Convert the inserted_row to a dictionary for JSON serialization
-                inserted_row_dict = inserted_row._asdict()
-
                 return create_success_response(
                     message="Translation created.",
-                    data=inserted_row_dict,
+                    data=inserted_row._asdict(),
                     status_code=201
                 )
 
@@ -1079,12 +1069,9 @@ def edit_translation(project, translation_id):
                         if inserted_row is None:
                             return create_error_response("Insertion failed: no row returned.", 500)
 
-                        # Convert the inserted_row to a dictionary for JSON serialization
-                        inserted_row_dict = inserted_row._asdict()
-
                         return create_success_response(
                             message="Translation text created.",
-                            data=inserted_row_dict,
+                            data=inserted_row._asdict(),
                             status_code=201
                         )
 
@@ -1114,12 +1101,9 @@ def edit_translation(project, translation_id):
                     if updated_row is None:
                         return create_error_response("Update failed: no translation text with the provided 'translation_text_id' found.")
 
-                    # Convert the inserted row to a dict for JSON serialization
-                    updated_row_dict = updated_row._asdict()
-
                     return create_success_response(
                         message="Translation text updated.",
-                        data=updated_row_dict
+                        data=updated_row._asdict()
                     )
 
     except Exception as e:

--- a/sls_api/endpoints/tools/events.py
+++ b/sls_api/endpoints/tools/events.py
@@ -517,19 +517,25 @@ def list_translations(project, translation_id):
     """
     List all translations for a given translation_id with optional filters.
 
-    Parameters:
+    URL Path Parameters:
+
     - project (str): project name.
-    - translation_id (str): The id of the translation object in the `translation` table. Must be a valid integer.
-    - Optional POST data parameters in JSON format:
-        - table_name (str): Filter translations by a specific table name.
-        - field_name (str): Filter translations by a specific field name.
-        - language (str): Filter translations by a specific language.
-        - translation_text_id (int): Filter translations by a specific id in the `translation_text` table.
+    - translation_id (str): The id of the translation object in the
+      `translation` table. Must be a valid integer.
+
+    POST Data Parameters in JSON Format (optional):
+    - table_name (str): Filter translations by a specific table name.
+    - field_name (str): Filter translations by a specific field name.
+    - language (str): Filter translations by a specific language.
+    - translation_text_id (int): Filter translations by a specific id
+      in the `translation_text` table.
 
     Returns:
+
         JSON: A list of translation records or an error message.
 
     Example Request:
+
         POST /projectname/translations/1/list/
         Body:
         {
@@ -540,6 +546,7 @@ def list_translations(project, translation_id):
         }
 
     Example Response:
+
         [
             {
                 "translation_text_id": 123,
@@ -553,9 +560,10 @@ def list_translations(project, translation_id):
         ]
 
     Status Codes:
-        200 - OK: Returns the list of translations.
-        400 - Bad Request: Invalid or missing translation_id.
-        500 - Internal Server Error: Query or execution failed.
+
+    - 200 - OK: Returns the list of translations.
+    - 400 - Bad Request: Invalid or missing translation_id.
+    - 500 - Internal Server Error: Database query or execution failed.
     """
     # Convert translation_id to integer
     translation_id = int_or_none(translation_id)

--- a/sls_api/endpoints/tools/events.py
+++ b/sls_api/endpoints/tools/events.py
@@ -829,7 +829,10 @@ def add_new_translation(project):
                         return create_error_response("Validation error: 'parent_id' must be a positive integer.")
 
                     # Create a new translation base object
-                    translation_id = create_translation(request_data.get("neutral_text"))
+                    translation_id = create_translation(
+                        request_data.get("neutral_text"),
+                        connection
+                    )
 
                     if translation_id is None:
                         return create_error_response("Unexpected error: failed to create new translation.", 500)

--- a/sls_api/endpoints/tools/events.py
+++ b/sls_api/endpoints/tools/events.py
@@ -621,7 +621,7 @@ def edit_subject(project, subject_id):
                 values[field] = request_data[field]
 
     if not values:
-        return create_error_response(f"Validation error: no valid fields provided to update.")
+        return create_error_response("Validation error: no valid fields provided to update.")
 
     # Add date_modified
     values["date_modified"] = datetime.now()
@@ -885,7 +885,7 @@ def edit_translation(project, translation_id):
                 values[field] = request_data[field]
 
     if not values:
-        return create_error_response(f"Validation error: no valid fields provided to update.")
+        return create_error_response("Validation error: no valid fields provided to update.")
 
     translation_text_id = request_data.get("translation_text_id")
     if translation_text_id is None:

--- a/sls_api/endpoints/tools/events.py
+++ b/sls_api/endpoints/tools/events.py
@@ -192,12 +192,12 @@ def list_project_subjects(project, order_by="last_name", direction="asc"):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": array of objects or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a list of subject objects; `null` on error.
+    - `data`: On success, an array of subject objects; `null` on error.
 
     Example Request:
 
@@ -347,12 +347,12 @@ def add_new_subject(project):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the inserted subject
+    - `data`: On success, an object containing the inserted subject
       data; `null` on error.
 
     Example Request:
@@ -539,13 +539,13 @@ def edit_subject(project, subject_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the updated subject
-      data; `null` on error.
+    - `data`: On success, an object containing the updated subject data;
+      `null` on error.
 
     Example Request:
 
@@ -705,8 +705,8 @@ def add_new_translation(project):
 
     URL Path Parameters:
 
-    - project (str, required): The name of the project the translation belongs to
-      (must be a valid project name).
+    - project (str, required): The name of the project the translation
+      belongs to (must be a valid project name).
 
     POST Data Parameters in JSON Format:
 
@@ -734,13 +734,13 @@ def add_new_translation(project):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the inserted translation
-      text object; `null` on error.
+    - `data`: On success, an object containing the inserted translation
+      text data; `null` on error.
 
     Example Request:
 
@@ -944,13 +944,13 @@ def edit_translation(project, translation_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the updated translation
-      text object; `null` on error.
+    - `data`: On success, an object containing the updated translation
+      text data; `null` on error.
 
     Example Request:
 
@@ -1140,12 +1140,12 @@ def list_translations(project, translation_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": array of objects or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a list of translation text objects; `null` on
+    - `data`: On success, an array of translation text objects; `null` on
       error.
 
     Example Request:

--- a/sls_api/endpoints/tools/events.py
+++ b/sls_api/endpoints/tools/events.py
@@ -208,7 +208,7 @@ def list_project_subjects(project, order_by="last_name", direction="asc"):
 
         {
             "success": true,
-            "message": "Retrieved # records.",
+            "message": "Retrieved # person records.",
             "data": [
                 {
                     "id": 1,
@@ -299,7 +299,7 @@ def list_project_subjects(project, order_by="last_name", direction="asc"):
             rows = connection.execute(stmt).fetchall()
 
             return create_success_response(
-                message=f"Retrieved {len(rows)} records.",
+                message=f"Retrieved {len(rows)} person records.",
                 data=[row._asdict() for row in rows]
             )
 
@@ -1160,7 +1160,7 @@ def list_translations(project, translation_id):
 
         {
             "success": true,
-            "message": "Retrieved # records.",
+            "message": "Retrieved # translation texts.",
             "data": [
                 {
                     "translation_text_id": 123,
@@ -1254,7 +1254,7 @@ def list_translations(project, translation_id):
                 rows = connection.execute(statement).fetchall()
 
                 return create_success_response(
-                    message=f"Retrieved {len(rows)} records.",
+                    message=f"Retrieved {len(rows)} translation texts.",
                     data=[row._asdict() for row in rows]
                 )
 

--- a/sls_api/endpoints/tools/publications.py
+++ b/sls_api/endpoints/tools/publications.py
@@ -53,7 +53,7 @@ def get_publications(project, order_by="id", direction="asc"):
 
         {
             "success": true,
-            "message": "Retrieved # records.",
+            "message": "Retrieved # publications.",
             "data": [
                 {
                     "id": 1,
@@ -131,7 +131,7 @@ def get_publications(project, order_by="id", direction="asc"):
             rows = connection.execute(stmt).fetchall()
 
             return create_success_response(
-                message=f"Retrieved {len(rows)} records.",
+                message=f"Retrieved {len(rows)} publications.",
                 data=[row._asdict() for row in rows]
             )
 
@@ -176,7 +176,7 @@ def get_publication(project, publication_id):
 
         {
             "success": true,
-            "message": "Retrieved 1 record.",
+            "message": "Retrieved 1 publication.",
             "data": {
                 "id": 123,
                 "publication_collection_id": 456,
@@ -242,7 +242,7 @@ def get_publication(project, publication_id):
                 return create_error_response("Validation error: could not find publication, either 'project' or 'publication_id' is invalid.")
 
             return create_success_response(
-                message="Retrieved 1 record.",
+                message="Retrieved 1 publication.",
                 data=result._asdict()
             )
 
@@ -289,7 +289,7 @@ def get_publication_versions(project, publication_id):
 
         {
             "success": true,
-            "message": "Retrieved # records.",
+            "message": "Retrieved # publication versions.",
             "data": [
                 {
                     "id": 1,
@@ -352,7 +352,7 @@ def get_publication_versions(project, publication_id):
             rows = connection.execute(stmt).fetchall()
 
             return create_success_response(
-                message=f"Retrieved {len(rows)} records.",
+                message=f"Retrieved {len(rows)} publication versions.",
                 data=[row._asdict() for row in rows]
             )
 
@@ -399,7 +399,7 @@ def get_publication_manuscripts(project, publication_id):
 
         {
             "success": true,
-            "message": "Retrieved # records.",
+            "message": "Retrieved # publication manuscripts.",
             "data": [
                 {
                     "id": 1,
@@ -463,7 +463,7 @@ def get_publication_manuscripts(project, publication_id):
             rows = connection.execute(stmt).fetchall()
 
             return create_success_response(
-                message=f"Retrieved {len(rows)} records.",
+                message=f"Retrieved {len(rows)} publication manuscripts.",
                 data=[row._asdict() for row in rows]
             )
 
@@ -508,7 +508,7 @@ def get_publication_tags(project, publication_id):
 
         {
             "success": true,
-            "message": "Retrieved # records.",
+            "message": "Retrieved # publication tags.",
             "data": [
                 {
                     "id": 1,
@@ -569,7 +569,7 @@ def get_publication_tags(project, publication_id):
             ).fetchall()
 
             return create_success_response(
-                message=f"Retrieved {len(rows)} records.",
+                message=f"Retrieved {len(rows)} publication tags.",
                 data=[row._asdict() for row in rows]
             )
 
@@ -615,7 +615,7 @@ def get_publication_facsimiles(project, publication_id):
 
         {
             "success": true,
-            "message": "Retrieved # records.",
+            "message": "Retrieved # publication facsimiles.",
             "data": [
                 {
                     "id": 123,
@@ -687,7 +687,7 @@ def get_publication_facsimiles(project, publication_id):
             rows = connection.execute(stmt).fetchall()
 
             return create_success_response(
-                message=f"Retrieved {len(rows)} records.",
+                message=f"Retrieved {len(rows)} publication facsimiles.",
                 data=[row._asdict() for row in rows]
             )
 
@@ -734,7 +734,7 @@ def get_publication_comments(project, publication_id):
 
         {
             "success": true,
-            "message": "Retrieved # records.",
+            "message": "Retrieved # publication comments.",
             "data": [
                 {
                     "id": 2582,
@@ -798,7 +798,7 @@ def get_publication_comments(project, publication_id):
             rows = connection.execute(stmt).fetchall()
 
             return create_success_response(
-                message=f"Retrieved {len(rows)} records.",
+                message=f"Retrieved {len(rows)} publication comments.",
                 data=[row._asdict() for row in rows]
             )
 

--- a/sls_api/endpoints/tools/publications.py
+++ b/sls_api/endpoints/tools/publications.py
@@ -16,17 +16,21 @@ def get_publications(project):
     List all publications for a given project.
 
     URL Path Parameters:
+
     - project (str, required): The name of the project for which to retrieve
       publications.
 
     Returns:
+
         JSON: A list of publication objects within the specified project,
         an empty list if there are no publications, or an error message.
 
     Example Request:
+
         GET /projectname/publications/
 
     Example Response (Success):
+
         [
             {
                 "id": 1,
@@ -51,15 +55,16 @@ def get_publications(project):
         ]
 
     Example Response (Error):
+
         {
             "msg": "Invalid project name."
         }
 
     Status Codes:
-        200 - OK: The request was successful, and the publications are
-              returned.
-        400 - Bad Request: The project name is invalid.
-        500 - Internal Server Error: Database query or execution failed.
+
+    - 200 - OK: The request was successful, and the publications are returned.
+    - 400 - Bad Request: The project name is invalid.
+    - 500 - Internal Server Error: Database query or execution failed.
     """
     # Verify that project name is valid and get project_id
     project_id = get_project_id_from_name(project)
@@ -95,18 +100,22 @@ def get_publication(project, publication_id):
     Retrieve a single publication for a given project.
 
     URL Path Parameters:
+
     - project (str, required): The name of the project to which the
       publication belongs.
     - publication_id (int, required): The id of the publication to retrieve.
 
     Returns:
+
         JSON: A publication object within the specified project, or an error
         message if the publication is not found.
 
     Example Request:
+
         GET /projectname/publication/123/
 
     Example Response (Success):
+
         {
             "id": 123,
             "publication_collection_id": 456,
@@ -128,17 +137,19 @@ def get_publication(project, publication_id):
         }
 
     Example Response (Error):
+
         {
             "msg": "Publication not found. Either project name or
                     publication_id is invalid."
         }
 
     Status Codes:
-        200 - OK: The request was successful, and the publication is returned.
-        400 - Bad Request: The project name or publication_id is invalid.
-        404 - Not Found: The publication was not found within the specified
-              project.
-        500 - Internal Server Error: Database query or execution failed.
+
+    - 200 - OK: The request was successful, and the publication is returned.
+    - 400 - Bad Request: The project name or publication_id is invalid.
+    - 404 - Not Found: The publication was not found within the specified
+            project.
+    - 500 - Internal Server Error: Database query or execution failed.
     """
     # Verify that project name is valid and get project_id
     project_id = get_project_id_from_name(project)
@@ -378,9 +389,10 @@ def get_publication_tags(project, publication_id):
         GET /projectname/publication/456/tags/
 
     Status Codes:
-        200 - OK: The request was successful, and the publication tags are returned.
-        400 - Bad Request: The project name or publication_id is invalid.
-        500 - Internal Server Error: Database query or execution failed.
+
+    - 200 - OK: The request was successful, and the publication tags are returned.
+    - 400 - Bad Request: The project name or publication_id is invalid.
+    - 500 - Internal Server Error: Database query or execution failed.
     """
     # Verify that project name is valid and get project_id
     project_id = get_project_id_from_name(project)
@@ -593,13 +605,13 @@ def link_file_to_publication(project, publication_id):
     Create a new comment, manuscript or version for the specified publication
     in the given project.
 
-    URL path parameters:
+    URL Path Parameters:
 
     - project (str): The name of the project.
     - publication_id (int): The ID of the publication to which the comment,
       manuscript or version will be linked.
 
-    POST data parameters in JSON format:
+    POST Data Parameters in JSON Format:
 
     - file_type (str, required): The type of text to create.
       Must be one of "comment", "manuscript" or "version".
@@ -612,7 +624,7 @@ def link_file_to_publication(project, publication_id):
 
     - name (str, optional): The name or title of the text.
     - type (int, optional): A non-negative integer representing the type of
-      the file. Defaults to 1 for "version".
+      the file. Defaults to 1 for "version" (1=base text, 2=other variant).
     - section_id (int, optional): A non-negative integer representing the
       section ID.
     - sort_order (int, optional): A non-negative integer indicating the
@@ -822,7 +834,7 @@ def link_file_to_publication(project, publication_id):
                 }), 201
 
     except Exception as e:
-            return jsonify({
-                "msg": f"Failed to create new publication {file_type}.",
-                "reason": str(e)
-            }), 500
+        return jsonify({
+            "msg": f"Failed to create new publication {file_type}.",
+            "reason": str(e)
+        }), 500

--- a/sls_api/endpoints/tools/publications.py
+++ b/sls_api/endpoints/tools/publications.py
@@ -759,7 +759,7 @@ def link_text_to_publication(project, publication_id):
                 continue
 
             # Validate integer field values and ensure all other fields are
-            # strings
+            # strings or None
             if field == "published":
                 if not validate_int(request_data[field], 0, 2):
                     return jsonify({"msg": f"Field '{field}' must be an integer with value 0, 1 or 2."}), 400
@@ -767,8 +767,9 @@ def link_text_to_publication(project, publication_id):
                 if not validate_int(request_data[field], 0):
                     return jsonify({"msg": f"Field '{field}' must be a non-negative integer."}), 400
             else:
-                # Convert remaining fields to string
-                request_data[field] = str(request_data[field])
+                # Convert remaining fields to string if not None
+                if request_data[field] is not None:
+                    request_data[field] = str(request_data[field])
 
             # Add the field to the values list for the query construction
             values[field] = request_data[field]

--- a/sls_api/endpoints/tools/publications.py
+++ b/sls_api/endpoints/tools/publications.py
@@ -1045,7 +1045,6 @@ def link_text_to_publication(project, publication_id):
                 inserted_row = connection.execute(ins_stmt).first()
 
                 if inserted_row is None:
-                    # No row was returned; handle accordingly
                     return create_error_response("Insertion failed: no row returned.", 500)
 
                 if text_type == "comment":
@@ -1057,12 +1056,9 @@ def link_text_to_publication(project, publication_id):
                     )
                     connection.execute(upd_stmt)
 
-                # Convert the inserted row to a dict for JSON serialization
-                inserted_row_dict = inserted_row._asdict()
-
                 return create_success_response(
                     message=f"Publication {text_type} created and linked to publication.",
-                    data=inserted_row_dict,
+                    data=inserted_row._asdict(),
                     status_code=201
                 )
 

--- a/sls_api/endpoints/tools/publications.py
+++ b/sls_api/endpoints/tools/publications.py
@@ -31,43 +31,59 @@ def get_publications(project, order_by="id", direction="asc"):
 
     Returns:
 
-        JSON: A list of publication objects within the specified project,
-        an empty list if there are no publications, or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a list of publication objects; `null` on error.
 
     Example Request:
 
         GET /projectname/publications/
         GET /projectname/publications/date_modified/desc/
 
-    Example Response (Success):
-
-        [
-            {
-                "id": 1,
-                "publication_collection_id": 123,
-                "publication_comment_id": 5487,
-                "date_created": "2023-05-12T12:34:56",
-                "date_modified": "2023-06-01T08:22:11",
-                "date_published_externally": null,
-                "deleted": 0,
-                "published": 1,
-                "legacy_id": null,
-                "published_by": null,
-                "original_filename": "/path/to/file.xml",
-                "name": "Publication Title",
-                "genre": "non-fiction",
-                "publication_group_id": null,
-                "original_publication_date": "1854",
-                "zts_id": null,
-                "language": "en"
-            },
-            ...
-        ]
-
-    Example Response (Error):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "Invalid project name."
+            "success": true,
+            "message": "Retrieved # records.",
+            "data": [
+                {
+                    "id": 1,
+                    "publication_collection_id": 123,
+                    "publication_comment_id": 5487,
+                    "date_created": "2023-05-12T12:34:56",
+                    "date_modified": "2023-06-01T08:22:11",
+                    "date_published_externally": null,
+                    "deleted": 0,
+                    "published": 1,
+                    "legacy_id": null,
+                    "published_by": null,
+                    "original_filename": "/path/to/file.xml",
+                    "name": "Publication Title",
+                    "genre": "non-fiction",
+                    "publication_group_id": null,
+                    "original_publication_date": "1854",
+                    "zts_id": null,
+                    "language": "en"
+                },
+                ...
+            ]
+        }
+
+    Example Error Response (HTTP 400):
+
+        {
+            "success": false,
+            "message": "Validation error: 'project' does not exist.",
+            "data": null
         }
 
     Status Codes:
@@ -138,48 +154,62 @@ def get_publication(project, publication_id):
 
     Returns:
 
-        JSON: A publication object within the specified project, or an error
-        message if the publication is not found.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the publication data; `null`
+      on error.
 
     Example Request:
 
         GET /projectname/publication/123/
 
-    Example Response (Success):
+    Example Success Response (HTTP 200):
 
         {
-            "id": 123,
-            "publication_collection_id": 456,
-            "publication_comment_id": 789,
-            "date_created": "2023-05-12T12:34:56",
-            "date_modified": "2023-06-01T08:22:11",
-            "date_published_externally": null,
-            "deleted": 0,
-            "published": 1,
-            "legacy_id": null,
-            "published_by": null,
-            "original_filename": "/path/to/file.xml",
-            "name": "Publication Title",
-            "genre": "fiction",
-            "publication_group_id": null,
-            "original_publication_date": "1854",
-            "zts_id": null,
-            "language": "en"
+            "success": true,
+            "message": "Retrieved 1 record.",
+            "data": {
+                "id": 123,
+                "publication_collection_id": 456,
+                "publication_comment_id": 789,
+                "date_created": "2023-05-12T12:34:56",
+                "date_modified": "2023-06-01T08:22:11",
+                "date_published_externally": null,
+                "deleted": 0,
+                "published": 1,
+                "legacy_id": null,
+                "published_by": null,
+                "original_filename": "/path/to/file.xml",
+                "name": "Publication Title",
+                "genre": "fiction",
+                "publication_group_id": null,
+                "original_publication_date": "1854",
+                "zts_id": null,
+                "language": "en"
+            }
         }
 
-    Example Response (Error):
+    Example Error Response (HTTP 400):
 
         {
-            "msg": "Publication not found. Either project name or
-                    publication_id is invalid."
+            "success": false,
+            "message": "Validation error: 'project' does not exist.",
+            "data": null
         }
 
     Status Codes:
 
     - 200 - OK: The request was successful, and the publication is returned.
     - 400 - Bad Request: The project name or publication_id is invalid.
-    - 404 - Not Found: The publication was not found within the specified
-            project.
     - 500 - Internal Server Error: Database query or execution failed.
     """
     # Verify that project name is valid and get project_id
@@ -237,39 +267,56 @@ def get_publication_versions(project, publication_id):
 
     Returns:
 
-        JSON: A list of publication version objects for the specified
-        publication, or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a list of publication version objects; `null` on
+      error.
 
     Example Request:
 
         GET /projectname/publication/456/versions/
 
-    Example Response (Success):
-
-        [
-            {
-                "id": 1,
-                "publication_id": 456,
-                "date_created": "2023-07-12T09:23:45",
-                "date_modified": "2023-07-13T10:00:00",
-                "date_published_externally": null,
-                "deleted": 0,
-                "published": 1,
-                "legacy_id": null,
-                "published_by": null,
-                "original_filename": "path/to/file.xml",
-                "name": "Publication Title version 2",
-                "type": 1,
-                "section_id": 5,
-                "sort_order": 1
-            },
-            ...
-        ]
-
-    Example Response (Error):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "Invalid publication_id, must be a positive integer."
+            "success": true,
+            "message": "Retrieved # records.",
+            "data": [
+                {
+                    "id": 1,
+                    "publication_id": 456,
+                    "date_created": "2023-07-12T09:23:45",
+                    "date_modified": "2023-07-13T10:00:00",
+                    "date_published_externally": null,
+                    "deleted": 0,
+                    "published": 1,
+                    "legacy_id": null,
+                    "published_by": null,
+                    "original_filename": "path/to/file.xml",
+                    "name": "Publication Title version 2",
+                    "type": 1,
+                    "section_id": 5,
+                    "sort_order": 1
+                },
+                ...
+            ]
+        }
+
+    Example Error Response (HTTP 400):
+
+        {
+            "success": false,
+            "message": "Validation error: 'project' does not exist.",
+            "data": null
         }
 
     Status Codes:
@@ -330,40 +377,57 @@ def get_publication_manuscripts(project, publication_id):
 
     Returns:
 
-        JSON: A list of manuscript objects for the specified publication,
-        or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a list of publication manuscript objects; `null`
+      on error.
 
     Example Request:
 
         GET /projectname/publication/456/manuscripts/
 
-    Example Response (Success):
-
-        [
-            {
-                "id": 1,
-                "publication_id": 456,
-                "date_created": "2023-07-12T09:23:45",
-                "date_modified": "2023-07-13T10:00:00",
-                "date_published_externally": null,
-                "deleted": 0,
-                "published": 1,
-                "legacy_id": null,
-                "published_by": null,
-                "original_filename": "path/to/file.xml",
-                "name": "Publication Title manuscript 1",
-                "type": 1,
-                "section_id": 5,
-                "sort_order": 1,
-                "language": "en"
-            },
-            ...
-        ]
-
-    Example Response (Error):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "Invalid publication_id, must be a positive integer."
+            "success": true,
+            "message": "Retrieved # records.",
+            "data": [
+                {
+                    "id": 1,
+                    "publication_id": 456,
+                    "date_created": "2023-07-12T09:23:45",
+                    "date_modified": "2023-07-13T10:00:00",
+                    "date_published_externally": null,
+                    "deleted": 0,
+                    "published": 1,
+                    "legacy_id": null,
+                    "published_by": null,
+                    "original_filename": "path/to/file.xml",
+                    "name": "Publication Title manuscript 1",
+                    "type": 1,
+                    "section_id": 5,
+                    "sort_order": 1,
+                    "language": "en"
+                },
+                ...
+            ]
+        }
+
+    Example Error Response (HTTP 400):
+
+        {
+            "success": false,
+            "message": "Validation error: 'project' does not exist.",
+            "data": null
         }
 
     Status Codes:
@@ -423,12 +487,44 @@ def get_publication_tags(project, publication_id):
 
     Returns:
 
-        JSON: A list of tag objects for the specified publication, or an
-        error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a list of tag objects; `null` on error.
 
     Example Request:
 
         GET /projectname/publication/456/tags/
+
+    Example Success Response (HTTP 200):
+
+        {
+            "success": true,
+            "message": "Retrieved # records.",
+            "data": [
+                {
+                    "id": 1,
+                    ...
+                },
+                ...
+            ]
+        }
+
+    Example Error Response (HTTP 400):
+
+        {
+            "success": false,
+            "message": "Validation error: 'project' does not exist.",
+            "data": null
+        }
 
     Status Codes:
 
@@ -498,12 +594,57 @@ def get_publication_facsimiles(project, publication_id):
 
     Returns:
 
-        JSON: A list of fascimile objects for the specified publication,
-        or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a list of facsimile objects; `null` on error.
 
     Example Request:
 
         GET /projectname/publication/456/fascimiles/
+
+    Example Success Response (HTTP 200):
+
+        {
+            "success": true,
+            "message": "Retrieved # records.",
+            "data": [
+                {
+                    "id": 123,
+                    "publication_facsimile_collection_id": 5830,
+                    "publication_id": 456,
+                    "publication_manuscript_id": null,
+                    "publication_version_id": null,
+                    "date_created": "2023-05-12T12:34:56",
+                    "date_modified": "2023-06-01T08:22:11",
+                    "deleted": 0,
+                    "page_nr": 4,
+                    "section_id": 1,
+                    "priority": 1,
+                    "type": 0,
+                    "title": "Facsimile Collection Title",
+                    "description": "Some details about the collection.",
+                    "external_url": null
+                },
+                ...
+            ]
+        }
+
+    Example Error Response (HTTP 400):
+
+        {
+            "success": false,
+            "message": "Validation error: 'project' does not exist.",
+            "data": null
+        }
 
     Status Codes:
 
@@ -560,7 +701,8 @@ def get_publication_facsimiles(project, publication_id):
 def get_publication_comments(project, publication_id):
     """
     List all (non-deleted) comments of the specified publication
-    in a given project.
+    in a given project. Since only one comment is allowed per publication,
+    the list will have only one item (or none).
 
     URL Path Parameters:
 
@@ -571,36 +713,50 @@ def get_publication_comments(project, publication_id):
 
     Returns:
 
-        JSON: A list of publication comment objects for the specified
-        publication, or an error message. Currently, publications can have
-        only one comment, so the list will have either only one item or no
-        items.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a list of publication comment objects; `null` on error.
 
     Example Request:
 
         GET /projectname/publication/456/comments/
 
-    Example Response (Success):
-
-        [
-            {
-                "id": 2582,
-                "publication_id": 456,
-                "date_created": "2023-07-12T09:23:45",
-                "date_modified": "2023-07-13T10:00:00",
-                "date_published_externally": null,
-                "deleted": 0,
-                "published": 1,
-                "legacy_id": null,
-                "published_by": null,
-                "original_filename": "path/to/comment_file.xml"
-            }
-        ]
-
-    Example Response (Error):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "Invalid publication_id, must be a positive integer."
+            "success": true,
+            "message": "Retrieved # records.",
+            "data": [
+                {
+                    "id": 2582,
+                    "publication_id": 456,
+                    "date_created": "2023-07-12T09:23:45",
+                    "date_modified": "2023-07-13T10:00:00",
+                    "date_published_externally": null,
+                    "deleted": 0,
+                    "published": 1,
+                    "legacy_id": null,
+                    "published_by": null,
+                    "original_filename": "path/to/comment_file.xml"
+                }
+            ]
+        }
+
+    Example Error Response (HTTP 400):
+
+        {
+            "success": false,
+            "message": "Validation error: 'project' does not exist.",
+            "data": null
         }
 
     Status Codes:
@@ -679,7 +835,7 @@ def link_text_to_publication(project, publication_id):
 
     - name (str, optional): The name or title of the text.
     - type (int, optional): A non-negative integer representing the type of
-      the file. Defaults to 1 for "version" (1=base text, 2=other variant).
+      the text. Defaults to 1 for "version" (1=base text, 2=other variant).
     - section_id (int, optional): A non-negative integer representing the
       section ID.
     - sort_order (int, optional): A non-negative integer indicating the
@@ -690,7 +846,7 @@ def link_text_to_publication(project, publication_id):
     - language (str, optional): The language code (ISO 639-1) of the main
       language in the manuscript text.
 
-    For all file types:
+    For all text types:
 
     - published (int, optional): The publication status. Must be an integer
       with value 0, 1 or 2. Defaults to 1.
@@ -700,11 +856,23 @@ def link_text_to_publication(project, publication_id):
 
     Returns:
 
-        JSON: A success message with the inserted row data or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the inserted data; `null`
+      on error.
 
     Example Request:
 
-        POST /projectname/publication/456/link_file/
+        POST /projectname/publication/456/link_text/
         Body:
         {
             "text_type": "manuscript",
@@ -714,11 +882,12 @@ def link_text_to_publication(project, publication_id):
             "published": 1
         }
 
-    Example Response (Success):
+    Example Success Response (HTTP 201):
 
         {
-            "msg": "Publication manuscript with ID 123 created successfully.",
-            "row": {
+            "success": true,
+            "message": "Publication manuscript created and linked to publication.",
+            "data":  {
                 "id": 284,
                 "publication_id": 456,
                 "date_created": "2023-07-12T09:23:45",
@@ -737,10 +906,12 @@ def link_text_to_publication(project, publication_id):
             }
         }
 
-    Example Response (Error):
+    Example Error Response (HTTP 400):
 
         {
-            "msg": "POST data is invalid: required fields are missing or empty, or 'text_type' has an invalid value."
+            "success": false,
+            "message": "Validation error: 'original_filename' and 'text_type' required. Valid values for 'text_type' are 'comment', 'manuscript' or 'version'.",
+            "data": null
         }
 
     Status Codes:
@@ -748,8 +919,6 @@ def link_text_to_publication(project, publication_id):
     - 201 - Created: The publication text type was created successfully.
     - 400 - Bad Request: Invalid project name, publication ID, field values,
             or no data provided.
-    - 404 - Not Found: Publication not found or does not belong to the
-            specified project.
     - 500 - Internal Server Error: Database query or execution failed.
     """
     # Verify that project name is valid and get project_id

--- a/sls_api/endpoints/tools/publications.py
+++ b/sls_api/endpoints/tools/publications.py
@@ -37,12 +37,12 @@ def get_publications(project, order_by="id", direction="asc"):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": array of objects or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a list of publication objects; `null` on error.
+    - `data`: On success, an array of publication objects; `null` on error.
 
     Example Request:
 
@@ -160,12 +160,12 @@ def get_publication(project, publication_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the publication data; `null`
+    - `data`: On success, an object containing the publication data; `null`
       on error.
 
     Example Request:
@@ -273,12 +273,12 @@ def get_publication_versions(project, publication_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": array of objects or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a list of publication version objects; `null` on
+    - `data`: On success, an array of publication version objects; `null` on
       error.
 
     Example Request:
@@ -383,12 +383,12 @@ def get_publication_manuscripts(project, publication_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": array of objects or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a list of publication manuscript objects; `null`
+    - `data`: On success, an array of publication manuscript objects; `null`
       on error.
 
     Example Request:
@@ -493,12 +493,12 @@ def get_publication_tags(project, publication_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": array of objects or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a list of tag objects; `null` on error.
+    - `data`: On success, an array of tag objects; `null` on error.
 
     Example Request:
 
@@ -600,12 +600,12 @@ def get_publication_facsimiles(project, publication_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": array of objects or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a list of facsimile objects; `null` on error.
+    - `data`: On success, an array of facsimile objects; `null` on error.
 
     Example Request:
 
@@ -719,12 +719,13 @@ def get_publication_comments(project, publication_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": array of objects or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a list of publication comment objects; `null` on error.
+    - `data`: On success, an array of publication comment objects; `null`
+      on error.
 
     Example Request:
 
@@ -862,12 +863,12 @@ def link_text_to_publication(project, publication_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the inserted data; `null`
+    - `data`: On success, an object containing the inserted data; `null`
       on error.
 
     Example Request:

--- a/sls_api/endpoints/tools/publications.py
+++ b/sls_api/endpoints/tools/publications.py
@@ -13,7 +13,7 @@ publication_tools = Blueprint("publication_tools", __name__)
 @jwt_required()
 def get_publications(project):
     """
-    List all publications for a given project.
+    List all (non-deleted) publications for a given project.
 
     URL Path Parameters:
 
@@ -82,6 +82,7 @@ def get_publications(project):
                 select(*publication_table.c)
                 .join(collection_table, publication_table.c.publication_collection_id == collection_table.c.id)
                 .where(collection_table.c.project_id == project_id)
+                .where(publication_table.c.deleted < 1)
                 .order_by(publication_table.c.publication_collection_id)
             )
             rows = connection.execute(statement).fetchall()
@@ -190,8 +191,8 @@ def get_publication(project, publication_id):
 @jwt_required()
 def get_publication_versions(project, publication_id):
     """
-    List all versions (i.e. variants) of the specified publication in a
-    given project.
+    List all (non-deleted) versions (i.e. variants) of the specified
+    publication in a given project.
 
     URL Path Parameters:
 
@@ -280,7 +281,8 @@ def get_publication_versions(project, publication_id):
 @jwt_required()
 def get_publication_manuscripts(project, publication_id):
     """
-    List all manuscripts of the specified publication in a given project.
+    List all (non-deleted) manuscripts of the specified publication in
+    a given project.
 
     URL Path Parameters:
 
@@ -370,7 +372,7 @@ def get_publication_manuscripts(project, publication_id):
 @jwt_required()
 def get_publication_tags(project, publication_id):
     """
-    List all tags for the specified publication.
+    List all (non-deleted) tags for the specified publication.
 
     URL Path Parameters:
 
@@ -441,7 +443,8 @@ def get_publication_tags(project, publication_id):
 @jwt_required()
 def get_publication_facsimiles(project, publication_id):
     """
-    List all fascimiles for the specified publication in the given project.
+    List all (non-deleted) fascimiles for the specified publication in
+    the given project.
 
     URL Path Parameters:
 
@@ -510,7 +513,8 @@ def get_publication_facsimiles(project, publication_id):
 @jwt_required()
 def get_publication_comments(project, publication_id):
     """
-    List all comments of the specified publication in a given project.
+    List all (non-deleted) comments of the specified publication
+    in a given project.
 
     URL Path Parameters:
 

--- a/sls_api/endpoints/tools/publications.py
+++ b/sls_api/endpoints/tools/publications.py
@@ -770,7 +770,7 @@ def link_file_to_publication(project, publication_id):
                 # Convert remaining fields to string
                 request_data[field] = str(request_data[field])
 
-            # Add the field to the field_names list for the query construction
+            # Add the field to the values list for the query construction
             values[field] = request_data[field]
 
     # Set published to default value 1 if not in provided values

--- a/sls_api/endpoints/tools/publications.py
+++ b/sls_api/endpoints/tools/publications.py
@@ -557,7 +557,7 @@ def get_publication_comments(project, publication_id):
     publication_id = int_or_none(publication_id)
     if not publication_id or publication_id < 1:
         return jsonify({"msg": "Invalid publication_id, must be a positive integer."}), 400
-    
+
     publication_table = get_table("publication")
     comment_table = get_table("publication_comment")
 
@@ -570,7 +570,7 @@ def get_publication_comments(project, publication_id):
             # Left join publication table on publication_comment
             # table and filter on publication_id and non-deleted
             # comments. Publications can have only one comment,
-            # so this should return only one row.
+            # so this should return only one row (or none).
             stmt = (
                 select(*comment_table.c)
                 .join(publication_table, comment_table.c.id == publication_table.c.publication_comment_id)

--- a/sls_api/endpoints/tools/publications.py
+++ b/sls_api/endpoints/tools/publications.py
@@ -176,42 +176,6 @@ def get_publication(project, publication_id):
                         "reason": str(e)}), 500
 
 
-@publication_tools.route("/<project>/publication/manuscript/<publication_id>/")
-@project_permission_required
-def get_publication_manuscript(project, publication_id):
-    """
-    Get a publication object from the database
-    """
-    connection = db_engine.connect()
-    publication_ms = get_table("publication_manuscript")
-    statement = select(publication_ms).where(publication_ms.c.publication_id == int_or_none(publication_id))
-    rows = connection.execute(statement).fetchall()
-    result = []
-    for row in rows:
-        if row is not None:
-            result.append(row._asdict())
-    connection.close()
-    return jsonify(result)
-
-
-@publication_tools.route("/<project>/publication/version/<publication_id>/")
-@project_permission_required
-def get_publication_version(project, publication_id):
-    """
-    Get a publication object from the database
-    """
-    connection = db_engine.connect()
-    publication_v = get_table("publication_version")
-    statement = select(publication_v).where(publication_v.c.publication_id == int_or_none(publication_id))
-    rows = connection.execute(statement).fetchall()
-    result = []
-    for row in rows:
-        if row is not None:
-            result.append(row._asdict())
-    connection.close()
-    return jsonify(result)
-
-
 @publication_tools.route("/<project>/publication/<publication_id>/versions/")
 @jwt_required()
 def get_publication_versions(project, publication_id):

--- a/sls_api/endpoints/tools/publishing.py
+++ b/sls_api/endpoints/tools/publishing.py
@@ -21,28 +21,51 @@ def list_user_projects():
 
     Returns:
 
-        JSON: A list of project objects the user has access to
-        or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
 
-    Example Response (Success):
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
 
-        [
-            {
-                "id": 1,
-                "date_created": "2023-05-12T12:34:56",
-                "date_modified": "2023-06-01T08:22:11",
-                "deleted": 0,
-                "published": 1,
-                "name": "project_name"
-            },
-            ...
-        ]
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a list of project objects; `null` on error.
+
+    Example Success Response (HTTP 200):
+
+        {
+            "success": true,
+            "message": "Retrieved # records.",
+            "data": [
+                {
+                    "id": 1,
+                    "date_created": "2023-05-12T12:34:56",
+                    "date_modified": "2023-06-01T08:22:11",
+                    "deleted": 0,
+                    "published": 1,
+                    "name": "project_name"
+                },
+                ...
+            ]
+        }
+
+    Example Error Response (HTTP 404):
+
+        {
+            "success": false,
+            "message": "Permissions error: user lacks access to any project.",
+            "data": null
+        }
 
     Status Codes:
 
     - 200 - OK: The request was successful, and the projects are returned.
     - 403 - Forbidden: The user doesn't have project permissions.
-    - 404 - Not Found: The user doesn't have access to any (non-deleted) project.
+    - 404 - Not Found: The user doesn't have access to any (non-deleted)
+            project.
     - 500 - Internal Server Error: Database query or execution failed.
     """
     # Get identity of current JWT user along with projects the user
@@ -97,7 +120,19 @@ def add_new_project():
 
     Returns:
 
-        JSON: A success message with the inserted row, or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the inserted project
+      data; `null` on error.
 
     Example Request:
 
@@ -107,11 +142,12 @@ def add_new_project():
             "name": "My New Project"
         }
 
-    Example Response (Success):
+    Example Success Response (HTTP 201):
 
         {
-            "msg": "Created new project.",
-            "row": {
+            "success": true,
+            "message": "Project created.",
+            "data": {
                 "id": 123,
                 "date_created": "2023-07-12T09:23:45",
                 "date_modified": null,
@@ -121,10 +157,12 @@ def add_new_project():
             }
         }
 
-    Example Response (Error):
+    Example Error Response (HTTP 400):
 
         {
-            "msg": "No data provided."
+            "success": false,
+            "message": "Validation error: 'name' required.",
+            "data": null
         }
 
     Status Codes:
@@ -221,43 +259,55 @@ def edit_project(project_id):
 
     Returns:
 
-        JSON: A message indicating the result of the operation and the
-        updated project row, or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the updated project
+      data; `null` on error.
 
     Example Request:
 
         POST /projects/123/edit/
         Body:
         {
-            "deleted": 0,
-            "published": 1
+            "published": 2
         }
 
-    Example Response (Success):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "Updated project with ID 123 successfully.",
-            "row": {
+            "success": true,
+            "message": "Project updated.",
+            "data": {
                 "id": 123,
                 "date_created": "2023-01-01T10:00:00",
                 "date_modified": "2023-10-17T12:34:56",
                 "deleted": 0,
-                "published": 1,
+                "published": 2,
                 "name": "projectname"
             }
         }
 
-    Example Response (Error):
+    Example Error Response (HTTP 400):
 
         {
-            "msg": "Invalid project_id, must be a positive integer."
+            "success": false,
+            "message": "Validation error: 'project_id' must be a positive integer.",
+            "data": null
         }
 
     Status Codes:
 
-    - 200: The project was successfully updated.
+    - 200 - OK: The project was successfully updated.
     - 400 - Bad Request: Invalid `project_id`, field values or no data provided.
-    - 404 - Not Found: No project exists with the specified `project_id`.
     - 500 - Internal Server Error: Database query or execution failed.
     """
     # Convert project_id to integer and verify
@@ -351,8 +401,19 @@ def edit_publication_collection(project, collection_id):
 
     Returns:
 
-        JSON: A success message with the updated publication collection row,
-        or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the updated publication
+      collection data; `null` on error.
 
     Example Request:
 
@@ -360,14 +421,15 @@ def edit_publication_collection(project, collection_id):
         Body:
         {
             "name": "Updated Collection Name",
-            "published": 1
+            "published": 2
         }
 
-    Example Response (Success):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "Publication collection with id 456 updated successfully.",
-            "row": {
+            "success": true,
+            "message": "Publication collection updated.",
+            "data": {
                 "id": 456,
                 "publication_collection_introduction_id": null,
                 "publication_collection_title_id": null,
@@ -376,17 +438,19 @@ def edit_publication_collection(project, collection_id):
                 "date_modified": "2023-08-14T14:29:02",
                 "date_published_externally": null,
                 "deleted": 0,
-                "published": 1,
+                "published": 2,
                 "name": "Updated Collection Name",
                 "legacy_id": null,
                 "name_translation_id": 4297
             }
         }
 
-    Example Response (Error):
+    Example Error Response (HTTP 400):
 
         {
-            "msg": "Field 'published' must be an integer with value 0, 1 or 2."
+            "success": false,
+            "message": "Validation error: 'published' must be either 0, 1 or 2.",
+            "data": null
         }
 
     Status Codes:
@@ -394,8 +458,6 @@ def edit_publication_collection(project, collection_id):
     - 200 - OK: The publication collection was updated successfully.
     - 400 - Bad Request: Invalid collection_id, invalid field values,
             or no valid fields provided for the update.
-    - 404 - Not Found: No publication collection with the given collection_id
-            exists or no changes were made.
     - 500 - Internal Server Error: Database query or execution failed.
     """
     # Verify that project is valid
@@ -638,12 +700,24 @@ def edit_publication(project, publication_id):
     - genre (str): The genre of the publication.
     - deleted (int): Soft delete flag. Must be an integer with value 0 or 1.
 
-    Additionally, all POST data parameter values can be set to null, except 'deleted'.
+    Additionally, all POST data parameter values can be set to null,
+    except 'deleted'.
 
     Returns:
 
-        JSON: A success message and the updated row if the publication was
-        updated, or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the updated publication
+      data; `null` on error.
 
     Example Request:
 
@@ -655,11 +729,12 @@ def edit_publication(project, publication_id):
             "language": "en"
         }
 
-    Example Response (Success):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "Publication with id 123 updated successfully.",
-            "row": {
+            "success": true,
+            "message": "Publication updated.",
+            "data": {
                 "id": 123,
                 "publication_collection_id": 585,
                 "publication_comment_id": 5487,
@@ -680,10 +755,12 @@ def edit_publication(project, publication_id):
             }
         }
 
-    Example Response (Error):
+    Example Error Response (HTTP 400):
 
         {
-            "msg": "Field 'published' must be an integer with value 0, 1 or 2."
+            "success": false,
+            "message": "Validation error: 'published' must be either 0, 1 or 2.",
+            "data": null
         }
 
     Status Codes:
@@ -691,8 +768,6 @@ def edit_publication(project, publication_id):
     - 200 - OK: The publication was updated successfully.
     - 400 - Bad Request: Invalid publication_id, invalid field values,
             or no valid fields provided for the update.
-    - 404 - Not Found: No publication with the given publication_id exists
-            or no changes were made.
     - 500 - Internal Server Error: Database query or execution failed.
     """
     # Verify that project name is valid and get project_id
@@ -802,7 +877,8 @@ def edit_publication(project, publication_id):
 @project_permission_required
 def edit_comment(project, publication_id):
     """
-    Edit a comment of the specified publication in the given project by updating its fields.
+    Edit a comment of the specified publication in the given project by
+    updating its fields.
 
     URL Path Parameters:
 
@@ -820,8 +896,19 @@ def edit_comment(project, publication_id):
 
     Returns:
 
-        JSON: A success message and the updated comment data if the
-        comment was updated, or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the updated comment
+      data; `null` on error.
 
     Example Request:
 
@@ -833,11 +920,12 @@ def edit_comment(project, publication_id):
             "original_filename": "path/to/updated_comment_file.xml"
         }
 
-    Example Response (Success):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "Updated comment of publication with ID 123 successfully.",
-            "row": {
+            "success": true,
+            "message": "Publication comment updated.",
+            "data": {
                 "id": 456,
                 "date_created": "2023-07-12T09:23:45",
                 "date_modified": "2023-08-14T14:29:02",
@@ -850,10 +938,12 @@ def edit_comment(project, publication_id):
             }
         }
 
-    Example Response (Error):
+    Example Error Response (HTTP 400):
 
         {
-            "msg": "Field 'published' must be an integer with value 0, 1 or 2."
+            "success": false,
+            "message": "Validation error: 'project' does not exist.",
+            "data": null
         }
 
     Status Codes:
@@ -861,8 +951,6 @@ def edit_comment(project, publication_id):
     - 200 - OK: The comment was updated successfully.
     - 400 - Bad Request: Invalid publication_id, invalid field values,
             no data provided, or no valid fields provided to update.
-    - 404 - Not Found: Publication not found in project, or comment
-            linked to publication not found.
     - 500 - Internal Server Error: Database query or execution failed.
     """
     # Verify that project name is valid and get project_id
@@ -988,8 +1076,19 @@ def edit_manuscript(project, manuscript_id):
 
     Returns:
 
-        JSON: A success message and the updated manuscript row if the
-        manuscript was updated, or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the updated manuscript
+      data; `null` on error.
 
     Example Request:
 
@@ -1002,11 +1101,12 @@ def edit_manuscript(project, manuscript_id):
             "name": "Updated Manuscript Title"
         }
 
-    Example Response (Success):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "Updated manuscript with ID 123 successfully.",
-            "row": {
+            "success": true,
+            "message": "Publication manuscript updated.",
+            "data": {
                 "id": 123,
                 "publication_id": 456,
                 "date_created": "2024-08-02T05:13:49",
@@ -1025,10 +1125,12 @@ def edit_manuscript(project, manuscript_id):
             }
         }
 
-    Example Response (Error):
+    Example Error Response (HTTP 400):
 
         {
-            "msg": "Field 'published' must be an integer with value 0, 1 or 2."
+            "success": false,
+            "message": "Validation error: 'manuscript_id' must be a positive integer.",
+            "data": null
         }
 
     Status Codes:
@@ -1178,8 +1280,19 @@ def edit_version(project, version_id):
 
     Returns:
 
-        JSON: A success message and the updated publication version row
-        if the version was updated, or an error message.
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": dict or None
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, a dictionary containing the updated publication
+      version data; `null` on error.
 
     Example Request:
 
@@ -1192,11 +1305,12 @@ def edit_version(project, version_id):
             "name": "Updated Version Title"
         }
 
-    Example Response (Success):
+    Example Success Response (HTTP 200):
 
         {
-            "msg": "Updated version with ID 123 successfully.",
-            "row": {
+            "success": true,
+            "message": "Publication version updated.",
+            "data": {
                 "id": 123,
                 "publication_id": 456,
                 "date_created": "2024-08-02T05:13:49",
@@ -1214,10 +1328,12 @@ def edit_version(project, version_id):
             }
         }
 
-    Example Response (Error):
+    Example Error Response (HTTP 400):
 
         {
-            "msg": "Field 'published' must be an integer with value 0, 1 or 2."
+            "success": false,
+            "message": "Validation error: 'project' does not exist.",
+            "data": null
         }
 
     Status Codes:

--- a/sls_api/endpoints/tools/publishing.py
+++ b/sls_api/endpoints/tools/publishing.py
@@ -224,15 +224,11 @@ def add_new_project():
                 inserted_row = connection.execute(insert_stmt).first()
 
                 if inserted_row is None:
-                    # No row was returned; handle accordingly
                     return create_error_response("Insertion failed: no row returned.", 500)
-
-                # Convert the inserted row to a dict for JSON serialization
-                inserted_row_dict = inserted_row._asdict()
 
                 return create_success_response(
                     message="Project created.",
-                    data=inserted_row_dict,
+                    data=inserted_row._asdict(),
                     status_code=201
                 )
 
@@ -366,12 +362,9 @@ def edit_project(project_id):
                     # No row was returned; project_id invalid
                     return create_error_response("Update failed: no project with the provided 'project_id' found.")
 
-                # Convert the inserted row to a dict for JSON serialization
-                updated_row_dict = updated_row._asdict()
-
                 return create_success_response(
                     message="Project updated.",
-                    data=updated_row_dict
+                    data=updated_row._asdict()
                 )
 
     except Exception as e:
@@ -520,15 +513,11 @@ def edit_publication_collection(project, collection_id):
                 updated_row = connection.execute(upd_stmt).first()
 
                 if updated_row is None:
-                    # No row was returned; handle accordingly
                     return create_error_response("Update failed: no publication collection with the provided 'collection_id' and 'project' found.")
-
-                # Convert the inserted row to a dict for JSON serialization
-                updated_row_dict = updated_row._asdict()
 
                 return create_success_response(
                     message="Publication collection updated.",
-                    data=updated_row_dict
+                    data=updated_row._asdict()
                 )
 
     except Exception as e:
@@ -857,15 +846,11 @@ def edit_publication(project, publication_id):
                 updated_row = connection.execute(upd_stmt).first()
 
                 if updated_row is None:
-                    # No row was returned; handle accordingly
                     return create_error_response("Update failed: no publication with the provided 'publication_id' found.")
-
-                # Convert the inserted row to a dict for JSON serialization
-                updated_row_dict = updated_row._asdict()
 
                 return create_success_response(
                     message="Publication updated.",
-                    data=updated_row_dict
+                    data=updated_row._asdict()
                 )
 
     except Exception as e:
@@ -1032,12 +1017,9 @@ def edit_comment(project, publication_id):
                 if updated_row is None:
                     return create_error_response("Update failed: no comment linked to the publication with the provided 'publication_id' found.")
 
-                # Convert the inserted row to a dict for JSON serialization
-                updated_row_dict = updated_row._asdict()
-
                 return create_success_response(
                     message="Publication comment updated.",
-                    data=updated_row_dict
+                    data=updated_row._asdict()
                 )
 
     except Exception as e:
@@ -1233,15 +1215,11 @@ def edit_manuscript(project, manuscript_id):
                 updated_row = connection.execute(upd_stmt).first()
 
                 if updated_row is None:
-                    # No row was returned; handle accordingly
                     return create_error_response("Update failed: no publication manuscript with the provided 'manuscript_id' found.")
-
-                # Convert the inserted row to a dict for JSON serialization
-                updated_row_dict = updated_row._asdict()
 
                 return create_success_response(
                     message="Publication manuscript updated.",
-                    data=updated_row_dict
+                    data=updated_row._asdict()
                 )
 
     except Exception as e:
@@ -1436,15 +1414,11 @@ def edit_version(project, version_id):
                 updated_row = connection.execute(upd_stmt).first()
 
                 if updated_row is None:
-                    # No row was returned; handle accordingly
                     return create_error_response("Update failed: no publication version with the provided 'version_id' found.")
-
-                # Convert the inserted row to a dict for JSON serialization
-                updated_row_dict = updated_row._asdict()
 
                 return create_success_response(
                     message="Publication version updated.",
-                    data=updated_row_dict
+                    data=updated_row._asdict()
                 )
 
     except Exception as e:

--- a/sls_api/endpoints/tools/publishing.py
+++ b/sls_api/endpoints/tools/publishing.py
@@ -914,51 +914,6 @@ def edit_comment(project, publication_id):
         return jsonify(result), 500
 
 
-@publishing_tools.route("/<project>/publication/<publication_id>/manuscripts/new/", methods=["POST"])
-@project_permission_required
-def add_manuscript(project, publication_id):
-    """
-    Takes "title", "filename", "published", "sort_order" as JSON data
-    Returns "msg" and "manuscript_id" on success, otherwise 40x
-
-    Att! Use the "/<project>/publication/<publication_id>/link_file/" endpoint instead.
-    """
-    request_data = request.get_json()
-    if not request_data:
-        return jsonify({"msg": "No data provided."}), 400
-    title = request_data.get("title", None)
-    filename = request_data.get("filename", None)
-    published = request_data.get("published", None)
-    sort_order = request_data.get("sort_order", None)
-
-    publications = get_table("publication")
-    manuscripts = get_table("publication_manuscript")
-    connection = db_engine.connect()
-    with connection.begin():
-        query = select(publications).where(publications.c.id == int_or_none(publication_id))
-        result = connection.execute(query).fetchone()
-    if result is None:
-        connection.close()
-        return jsonify("No such publication exists."), 404
-
-    values = {"publication_id": int(publication_id)}
-    if title is not None:
-        values["name"] = title
-    if filename is not None:
-        values["original_filename"] = filename
-    if published is not None:
-        values["published"] = published
-    if sort_order is not None:
-        values["sort_order"] = sort_order
-    with connection.begin():
-        insert = manuscripts.insert().values(**values)
-        result = connection.execute(insert)
-        return jsonify({
-            "msg": "Created new manuscript object.",
-            "manuscript_id": int(result.inserted_primary_key[0])
-        }), 201
-
-
 @publishing_tools.route("/<project>/manuscripts/<manuscript_id>/edit/", methods=["POST"])
 @project_permission_required
 def edit_manuscript(project, manuscript_id):
@@ -1007,56 +962,6 @@ def edit_manuscript(project, manuscript_id):
     else:
         connection.close()
         return jsonify("No valid update values given."), 400
-
-
-@publishing_tools.route("/<project>/publication/<publication_id>/versions/new/", methods=["POST"])
-@project_permission_required
-def add_version(project, publication_id):
-    """
-    Takes "title", "filename", "published", "sort_order", "type" as JSON data
-    "type" denotes version type, 1=base text, 2=other variant
-    Returns "msg" and "version_id" on success, otherwise 40x
-
-    Att! Use the "/<project>/publication/<publication_id>/link_file/" endpoint instead.
-    """
-    request_data = request.get_json()
-    if not request_data:
-        return jsonify({"msg": "No data provided."}), 400
-    title = request_data.get("title", None)
-    filename = request_data.get("filename", None)
-    published = request_data.get("published", None)
-    sort_order = request_data.get("sort_order", None)
-    version_type = request_data.get("type", None)
-
-    publications = get_table("publication")
-    versions = get_table("publication_version")
-    connection = db_engine.connect()
-    with connection.begin():
-        query = select(publications).where(publications.c.id == int_or_none(publication_id))
-        result = connection.execute(query).fetchone()
-    if result is None:
-        connection.close()
-        return jsonify("No such publication exists."), 404
-
-    values = {"publication_id": int(publication_id)}
-    if title is not None:
-        values["name"] = title
-    if filename is not None:
-        values["original_filename"] = filename
-    if published is not None:
-        values["published"] = published
-    if sort_order is not None:
-        values["sort_order"] = sort_order
-    if version_type is not None:
-        values["type"] = version_type
-
-    with connection.begin():
-        insert = versions.insert().values(**values)
-        result = connection.execute(insert)
-        return jsonify({
-            "msg": "Created new version object.",
-            "version_id": int(result.inserted_primary_key[0])
-        }), 201
 
 
 @publishing_tools.route("/<project>/versions/<version_id>/edit/", methods=["POST"])

--- a/sls_api/endpoints/tools/publishing.py
+++ b/sls_api/endpoints/tools/publishing.py
@@ -1113,54 +1113,194 @@ def edit_manuscript(project, manuscript_id):
 @project_permission_required
 def edit_version(project, version_id):
     """
-    Takes "title", "filename", "published", "sort_order", "type" as JSON data
-    "type" denotes version type, 1=base text, 2=other variant
-    Returns "msg" and "version_id" on success, otherwise 40x
+    Edit a publication version of the specified project by updating its fields.
+
+    URL Path Parameters:
+
+    - project (str): The name of the project.
+    - version_id (str): The ID of the publication version to be updated.
+      Must be a valid integer.
+
+    POST Data Parameters in JSON Format (at least one required):
+
+    - publication_id (int): The ID of the publication linked to the version.
+      Must be a positive integer or null.
+    - deleted (int): Soft delete flag. Must be an integer with value 0 or 1.
+    - published (int): The publication status of the version. Must be an
+      integer with value 0, 1 or 2.
+    - original_filename (str): Path to the version’s XML file in the
+      project repository.
+    - name (str): The name of the version.
+    - type (int): The type of the version. Must be a non-negative integer.
+      1 denotes a base text and 2 some other variant.
+    - section_id (int): The ID of the section/chapter of the version.
+      Must be a non-negative integer.
+    - sort_order (int): The sorting order of the version. Must be a
+      non-negative integer.
+
+    Returns:
+
+        JSON: A success message and the updated publication version row
+        if the version was updated, or an error message.
+
+    Example Request:
+
+        POST /projectname/versions/123/edit/
+        Body:
+        {
+            "published": 1,
+            "deleted": 0,
+            "original_filename": "path/to/updated_version.xml",
+            "name": "Updated Version Title"
+        }
+
+    Example Response (Success):
+
+        {
+            "msg": "Updated version with ID 123 successfully.",
+            "row": {
+                "id": 123,
+                "publication_id": 456,
+                "date_created": "2024-08-02T05:13:49",
+                "date_modified": "2024-10-17T14:23:01",
+                "date_published_externally": null,
+                "deleted": 0,
+                "published": 1,
+                "legacy_id": null,
+                "published_by": null,
+                "original_filename": "path/to/updated_version.xml",
+                "name": "Updated Version Title",
+                "type": 1,
+                "section_id": 2,
+                "sort_order": 3
+            }
+        }
+
+    Example Response (Error):
+
+        {
+            "msg": "Field 'published' must be an integer with value 0, 1 or 2."
+        }
+
+    Status Codes:
+
+    - 200 - OK: The version was updated successfully.
+    - 400 - Bad Request: Invalid version_id, invalid field values, no data
+            provided, or no valid fields provided to update.
+    - 500 - Internal Server Error: Database query or execution failed.
     """
+    # Verify that project name is valid and get project_id
+    project_id = get_project_id_from_name(project)
+    if not project_id:
+        return jsonify({"msg": "Invalid project name."}), 400
+
+    # Verify that version_id is an integer
+    version_id = int_or_none(version_id)
+    if not version_id or version_id < 1:
+        return jsonify({"msg": "Invalid version_id."}), 400
+
+    # Verify that request data was provided
     request_data = request.get_json()
     if not request_data:
         return jsonify({"msg": "No data provided."}), 400
-    title = request_data.get("title", None)
-    filename = request_data.get("filename", None)
-    published = request_data.get("published", None)
-    sort_order = request_data.get("sort_order", None)
-    version_type = request_data.get("type", None)
 
-    versions = get_table("publication_version")
-    connection = db_engine.connect()
-    with connection.begin():
-        query = select(versions).where(versions.c.id == int_or_none(version_id))
-        result = connection.execute(query).fetchone()
-    if result is None:
-        connection.close()
-        return jsonify("No such version exists."), 404
+    # List of fields to check in request_data
+    fields = ["publication_id",
+              "deleted",
+              "published",
+              "original_filename",
+              "name",
+              "type",
+              "section_id",
+              "sort_order"]
 
+    # Start building values dictionary for update statement
     values = {}
-    if title is not None:
-        values["name"] = title
-    if filename is not None:
-        values["original_filename"] = filename
-    if published is not None:
-        values["published"] = published
-    if sort_order is not None:
-        values["sort_order"] = sort_order
-    if version_type is not None:
-        values["type"] = version_type
 
+    # Loop over all fields and validate them
+    for field in fields:
+        if field in request_data:
+            if request_data[field] is None and field != "deleted":
+                values[field] = None
+            else:
+                # Validate integer field values and ensure all other
+                # fields are strings
+                if field == "publication_id":
+                    if not validate_int(request_data[field], 1):
+                        return jsonify({"msg": f"Field '{field}' must be a positive integer (or null)."}), 400
+                elif field == "published":
+                    if not validate_int(request_data[field], 0, 2):
+                        return jsonify({"msg": f"Field '{field}' must be an integer with value 0, 1 or 2."}), 400
+                elif field == "deleted":
+                    if not validate_int(request_data[field], 0, 1):
+                        return jsonify({"msg": f"Field '{field}' must be an integer with value 0 or 1."}), 400
+                elif field in ["type", "section_id", "sort_order"]:
+                    if not validate_int(request_data[field], 0):
+                        return jsonify({"msg": f"Field '{field}' must be a non-negative integer."}), 400
+                else:
+                    # Convert remaining fields to string
+                    request_data[field] = str(request_data[field])
+
+                # Add the field to the values list for the query construction
+                values[field] = request_data[field]
+
+    if not values:
+        return jsonify({"msg": "No valid fields provided to update."}), 400
+
+    # Add date_modified
     values["date_modified"] = datetime.now()
 
-    if len(values) > 0:
-        with connection.begin():
-            update = versions.update().where(versions.c.id == int(version_id)).values(**values)
-            connection.execute(update)
-        connection.close()
-        return jsonify({
-            "msg": "Updated version {} with values {}".format(int(version_id), str(values)),
-            "manuscript_id": int(version_id)
-        })
-    else:
-        connection.close()
-        return jsonify("No valid update values given."), 400
+    try:
+        with db_engine.connect() as connection:
+            with connection.begin():
+                # ! We are not verifying that the version belongs to
+                # ! a publication in the specified project.
+
+                # Verify that publication_id is valid if it is updated
+                if (
+                    "publication_id" in values
+                    and values["publication_id"] is not None
+                ):
+                    publication_table = get_table("publication")
+                    stmt = (
+                        select(publication_table.c.id)
+                        .where(publication_table.c.id == values["publication_id"])
+                    )
+                    result = connection.execute(stmt).first()
+
+                    if result is None:
+                        return jsonify({"msg": f"Invalid publication_id in provided data. No publication with ID {values['publication_id']} exists."}), 400
+
+                # Proceed to updating the version
+                version_table = get_table("publication_version")
+                upd_stmt = (
+                    version_table.update()
+                    .where(version_table.c.id == version_id)
+                    .values(**values)
+                    .returning(*version_table.c)  # Return the updated row
+                )
+                result = connection.execute(upd_stmt)
+                updated_row = result.fetchone()  # Fetch the updated row
+
+                if updated_row is None:
+                    # No row was returned; handle accordingly
+                    return jsonify({"msg": "Update failed: invalid version_id or no changes were made."}), 400
+
+                # Convert the inserted row to a dict for JSON serialization
+                updated_row_dict = updated_row._asdict()
+
+                return jsonify({
+                    "msg": f"Updated version with ID {version_id} successfully.",
+                    "row": updated_row_dict
+                })
+
+    except Exception as e:
+        # Handle errors and return error response
+        result = {
+            "msg": f"Failed to update version with ID {version_id}.",
+            "reason": str(e)
+        }
+        return jsonify(result), 500
 
 
 @publishing_tools.route("/<project>/facsimile_collection/<collection_id>/edit/", methods=["POST"])

--- a/sls_api/endpoints/tools/publishing.py
+++ b/sls_api/endpoints/tools/publishing.py
@@ -464,7 +464,7 @@ def edit_publication_collection(project, collection_id):
                 if updated_row is None:
                     # No row was returned; handle accordingly
                     return jsonify({
-                        "msg": f"Update failed: No publication collection with ID {collection_id} exists in project with ID {project_id} or no changes were made."
+                        "msg": f"Update failed: No publication collection with ID {collection_id} exists in project with ID {project_id}."
                     }), 404
 
                 # Convert the inserted row to a dict for JSON serialization

--- a/sls_api/endpoints/tools/publishing.py
+++ b/sls_api/endpoints/tools/publishing.py
@@ -1303,57 +1303,6 @@ def edit_version(project, version_id):
         return jsonify(result), 500
 
 
-@publishing_tools.route("/<project>/facsimile_collection/<collection_id>/edit/", methods=["POST"])
-@project_permission_required
-def edit_facsimile_collection(project, collection_id):
-    """
-    Takes "title", "numberOfPages", "startPageNumber", "description" as JSON data
-    Returns "msg" and "facs_coll_id" on success, otherwise 40x
-    """
-    request_data = request.get_json()
-    if not request_data:
-        return jsonify({"msg": "No data provided."}), 400
-    title = request_data.get("title", None)
-    page_count = request_data.get("numberOfPages", None)
-    start_page = request_data.get("startPageNumber", None)
-    description = request_data.get("description", None)
-    external_url = request_data.get("external_url", None)
-    collections = get_table("publication_facsimile_collection")
-    connection = db_engine.connect()
-    with connection.begin():
-        query = select(collections).where(collections.c.id == int_or_none(collection_id))
-        result = connection.execute(query).fetchone()
-    if result is None:
-        connection.close()
-        return jsonify("No such facsimile collection exists."), 404
-
-    values = {}
-    if title is not None:
-        values["title"] = title
-    if page_count is not None:
-        values["number_of_pages"] = page_count
-    if start_page is not None:
-        values["start_page_number"] = start_page
-    if description is not None:
-        values["description"] = description
-    if external_url is not None:
-        values["external_url"] = external_url
-    values["date_modified"] = datetime.now()
-
-    if len(values) > 0:
-        with connection.begin():
-            update = collections.update().where(collections.c.id == int(collection_id)).values(**values)
-            connection.execute(update)
-        connection.close()
-        return jsonify({
-            "msg": "Updated facsimile collection {} with values {}".format(int(collection_id), str(values)),
-            "facs_coll_id": int(collection_id)
-        })
-    else:
-        connection.close()
-        return jsonify("No valid update values given."), 400
-
-
 @publishing_tools.route("/<project>/publication_collection/<collection_id>/info")
 @project_permission_required
 def get_publication_collection_info(project, collection_id):

--- a/sls_api/endpoints/tools/publishing.py
+++ b/sls_api/endpoints/tools/publishing.py
@@ -27,12 +27,12 @@ def list_user_projects():
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": array of objects or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a list of project objects; `null` on error.
+    - `data`: On success, an array of project objects; `null` on error.
 
     Example Success Response (HTTP 200):
 
@@ -126,13 +126,13 @@ def add_new_project():
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the inserted project
-      data; `null` on error.
+    - `data`: On success, an object containing the inserted project data;
+      `null` on error.
 
     Example Request:
 
@@ -262,13 +262,13 @@ def edit_project(project_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the updated project
-      data; `null` on error.
+    - `data`: On success, an object containing the updated project data;
+      `null` on error.
 
     Example Request:
 
@@ -405,12 +405,12 @@ def edit_publication_collection(project, collection_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the updated publication
+    - `data`: On success, an object containing the updated publication
       collection data; `null` on error.
 
     Example Request:
@@ -709,12 +709,12 @@ def edit_publication(project, publication_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the updated publication
+    - `data`: On success, an object containing the updated publication
       data; `null` on error.
 
     Example Request:
@@ -900,13 +900,13 @@ def edit_comment(project, publication_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data":  object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the updated comment
-      data; `null` on error.
+    - `data`: On success, an object containing the updated comment data;
+      `null` on error.
 
     Example Request:
 
@@ -1081,12 +1081,12 @@ def edit_manuscript(project, manuscript_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the updated manuscript
+    - `data`: On success, an object containing the updated manuscript
       data; `null` on error.
 
     Example Request:
@@ -1285,12 +1285,12 @@ def edit_version(project, version_id):
         {
             "success": bool,
             "message": str,
-            "data": dict or None
+            "data": object or null
         }
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, a dictionary containing the updated publication
+    - `data`: On success, an object containing the updated publication
       version data; `null` on error.
 
     Example Request:

--- a/sls_api/endpoints/tools/publishing.py
+++ b/sls_api/endpoints/tools/publishing.py
@@ -250,6 +250,7 @@ def edit_project(project_id):
     POST Data Parameters in JSON Format (at least one required):
 
     - deleted (int): Soft delete flag. Must be an integer with value 0 or 1.
+      Setting `deleted` value to 1 will force `published` value to 0.
     - published (int): The publication status of the project.
       Must be an integer with value 0, 1 or 2.
 
@@ -345,6 +346,9 @@ def edit_project(project_id):
 
     if values:
         values["date_modified"] = datetime.now()
+        # If "deleted" set to 1, force "published" to 0
+        if values.get("deleted"):
+            values["published"] = 0
 
     try:
         with db_engine.connect() as connection:
@@ -391,6 +395,7 @@ def edit_publication_collection(project, collection_id):
     - published (int): The publication status. Must be an integer with
       value 0, 1 or 2.
     - deleted (int): Soft delete flag. Must be an integer with value 0 or 1.
+      Setting `deleted` value to 1 will force `published` value to 0.
 
     Returns:
 
@@ -498,6 +503,9 @@ def edit_publication_collection(project, collection_id):
 
     # Add date_modified
     values["date_modified"] = datetime.now()
+    # If "deleted" set to 1, force "published" to 0
+    if values.get("deleted"):
+        values["published"] = 0
 
     try:
         with db_engine.connect() as connection:
@@ -688,6 +696,7 @@ def edit_publication(project, publication_id):
       publication (ISO 639-1).
     - genre (str): The genre of the publication.
     - deleted (int): Soft delete flag. Must be an integer with value 0 or 1.
+      Setting `deleted` value to 1 will force `published` value to 0.
 
     Additionally, all POST data parameter values can be set to null,
     except 'deleted'.
@@ -817,6 +826,9 @@ def edit_publication(project, publication_id):
 
     # Add date_modified
     values["date_modified"] = datetime.now()
+    # If "deleted" set to 1, force "published" to 0
+    if values.get("deleted"):
+        values["published"] = 0
 
     try:
         with db_engine.connect() as connection:
@@ -874,8 +886,9 @@ def edit_comment(project, publication_id):
     POST Data Parameters in JSON Format (at least one required):
 
     - deleted (int): Soft delete flag. Must be an integer with value 0 or 1.
+      Setting `deleted` value to 1 will force `published` value to 0.
     - published (int): The publication status of the comment. Must be an
-      integer with value 0, 1, or 2.
+      integer with value 0, 1 or 2.
     - original_filename (str): Path to the comment’s XML-file in the
       project GitHub repository.
 
@@ -983,6 +996,9 @@ def edit_comment(project, publication_id):
 
     # Add date_modified
     values["date_modified"] = datetime.now()
+    # If "deleted" set to 1, force "published" to 0
+    if values.get("deleted"):
+        values["published"] = 0
 
     try:
         with db_engine.connect() as connection:
@@ -1044,6 +1060,7 @@ def edit_manuscript(project, manuscript_id):
     - publication_id (int): The ID of the publication linked to the
       manuscript. Must be a positive integer or null.
     - deleted (int): Soft delete flag. Must be an integer with value 0 or 1.
+      Setting `deleted` value to 1 will force `published` value to 0.
     - published (int): The publication status of the manuscript.
       Must be an integer with value 0, 1 or 2.
     - original_filename (str): Path to the manuscript’s XML file
@@ -1182,6 +1199,9 @@ def edit_manuscript(project, manuscript_id):
 
     # Add date_modified
     values["date_modified"] = datetime.now()
+    # If "deleted" set to 1, force "published" to 0
+    if values.get("deleted"):
+        values["published"] = 0
 
     try:
         with db_engine.connect() as connection:
@@ -1244,6 +1264,7 @@ def edit_version(project, version_id):
     - publication_id (int): The ID of the publication linked to the version.
       Must be a positive integer or null.
     - deleted (int): Soft delete flag. Must be an integer with value 0 or 1.
+      Setting `deleted` value to 1 will force `published` value to 0.
     - published (int): The publication status of the version. Must be an
       integer with value 0, 1 or 2.
     - original_filename (str): Path to the version’s XML file in the
@@ -1381,6 +1402,9 @@ def edit_version(project, version_id):
 
     # Add date_modified
     values["date_modified"] = datetime.now()
+    # If "deleted" set to 1, force "published" to 0
+    if values.get("deleted"):
+        values["published"] = 0
 
     try:
         with db_engine.connect() as connection:

--- a/sls_api/endpoints/tools/publishing.py
+++ b/sls_api/endpoints/tools/publishing.py
@@ -583,7 +583,8 @@ def edit_publication(project, publication_id):
 
     Returns:
 
-        JSON: A success message if the publication was updated, or an error message.
+        JSON: A success message and the updated row if the publication was
+        updated, or an error message.
 
     Example Request:
 
@@ -598,7 +599,26 @@ def edit_publication(project, publication_id):
     Example Response (Success):
 
         {
-            "msg": "Publication with id 123 updated successfully."
+            "msg": "Publication with id 123 updated successfully.",
+            "row": {
+                "id": 123,
+                "publication_collection_id": 585,
+                "publication_comment_id": 5487,
+                "date_created": "2023-05-12T12:34:56",
+                "date_modified": "2023-06-01T08:22:11",
+                "date_published_externally": null,
+                "deleted": 0,
+                "published": 1,
+                "legacy_id": null,
+                "published_by": null,
+                "original_filename": "/path/to/file.xml",
+                "name": "New Publication Name",
+                "genre": "non-fiction",
+                "publication_group_id": null,
+                "original_publication_date": "1854",
+                "zts_id": null,
+                "language": "en"
+            }
         }
 
     Example Response (Error):
@@ -708,7 +728,7 @@ def edit_publication(project, publication_id):
                     return jsonify({
                         "msg": "Update failed: no row returned.",
                         "reason": "The update statement did not return any data."
-                    }), 500
+                    }), 404
 
                 # Convert the inserted row to a dict for JSON serialization
                 updated_row_dict = updated_row._asdict()

--- a/sls_api/endpoints/tools/publishing.py
+++ b/sls_api/endpoints/tools/publishing.py
@@ -211,7 +211,7 @@ def edit_project(project_id):
     # Verify that POST data contains at least one valid field
     if all(field not in request_data for field in fields):
         return jsonify({"msg": "POST data contains no valid fields."}), 400
-    
+
     # Start building values dictionary for update statement
     values = {}
 

--- a/sls_api/endpoints/tools/publishing.py
+++ b/sls_api/endpoints/tools/publishing.py
@@ -564,7 +564,6 @@ def edit_publication_collection(project, collection_id):
                         if casc_upd_result is None:
                             raise CascadeUpdateError(f"failed to update 'deleted' or 'published' field for {text_type} linked to the collection.")
 
-
                     # Get all non-deleted publications in the collection
                     publication_table = get_table("publication")
                     pub_stmt = (

--- a/sls_api/endpoints/tools/publishing.py
+++ b/sls_api/endpoints/tools/publishing.py
@@ -38,7 +38,7 @@ def list_user_projects():
 
         {
             "success": true,
-            "message": "Retrieved # records.",
+            "message": "Retrieved # projects.",
             "data": [
                 {
                     "id": 1,
@@ -93,7 +93,7 @@ def list_user_projects():
             rows = connection.execute(stmt).fetchall()
 
             return create_success_response(
-                message=f"Retrieved {len(rows)} records.",
+                message=f"Retrieved {len(rows)} projects.",
                 data=[row._asdict() for row in rows]
             )
 

--- a/sls_api/endpoints/tools/publishing.py
+++ b/sls_api/endpoints/tools/publishing.py
@@ -1,7 +1,7 @@
 import logging
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
-from sqlalchemy import select, text
+from sqlalchemy import select
 from datetime import datetime
 
 from sls_api.endpoints.generics import db_engine, get_project_id_from_name, get_table, int_or_none, \

--- a/sls_api/endpoints/tools/publishing.py
+++ b/sls_api/endpoints/tools/publishing.py
@@ -439,7 +439,7 @@ def edit_publication_collection(project, collection_id):
             values[field] = request_data[field]
 
     if not values:
-        return create_error_response(f"Validation error: no valid fields provided to update.")
+        return create_error_response("Validation error: no valid fields provided to update.")
 
     # Add date_modified
     values["date_modified"] = datetime.now()
@@ -749,7 +749,7 @@ def edit_publication(project, publication_id):
                 values[field] = request_data[field]
 
     if not values:
-        return create_error_response(f"Validation error: no valid fields provided to update.")
+        return create_error_response("Validation error: no valid fields provided to update.")
 
     # Add date_modified
     values["date_modified"] = datetime.now()
@@ -906,7 +906,7 @@ def edit_comment(project, publication_id):
             values[field] = request_data[field]
 
     if not values:
-        return create_error_response(f"Validation error: no valid fields provided to update.")
+        return create_error_response("Validation error: no valid fields provided to update.")
 
     # Add date_modified
     values["date_modified"] = datetime.now()
@@ -1094,7 +1094,7 @@ def edit_manuscript(project, manuscript_id):
                 values[field] = request_data[field]
 
     if not values:
-        return create_error_response(f"Validation error: no valid fields provided to update.")
+        return create_error_response("Validation error: no valid fields provided to update.")
 
     # Add date_modified
     values["date_modified"] = datetime.now()
@@ -1283,7 +1283,7 @@ def edit_version(project, version_id):
                 values[field] = request_data[field]
 
     if not values:
-        return create_error_response(f"Validation error: no valid fields provided to update.")
+        return create_error_response("Validation error: no valid fields provided to update.")
 
     # Add date_modified
     values["date_modified"] = datetime.now()

--- a/sls_api/endpoints/tools/publishing.py
+++ b/sls_api/endpoints/tools/publishing.py
@@ -19,19 +19,21 @@ def add_new_project():
     """
     Create a new project.
 
-    POST data parameters in JSON format:
+    POST Data Parameters in JSON Format:
+
     - name (str, required): The name/title of the new project. The name
       can only contain lowercase letters (a-z), digits (0-9) and
       underscores (_), and must be between 3 and 32 characters long
-      (inclusive).
-      The project name must be unique.
+      (inclusive). The project name must be unique.
     - published (int, required): The published status of the project.
       Must be an integer with values 0, 1 or 2. Defaults to 1.
 
     Returns:
+
         JSON: A success message with the id of the inserted project (`project_id`), or an error message.
 
     Example Request:
+
         POST /projects/new/
         Body:
         {
@@ -39,20 +41,24 @@ def add_new_project():
         }
 
     Example Response (Success):
+
         {
             "msg": "Created new project.",
             "project_id": 123
         }
 
     Example Response (Error):
+
         {
             "msg": "No data provided."
         }
 
     Status Codes:
-        201 - Created: The project was inserted successfully.
-        400 - Bad Request: No data was provided in the request, or required fields are missing.
-        500 - Internal Server Error: Database query or execution failed.
+
+    - 201 - Created: The project was inserted successfully.
+    - 400 - Bad Request: No data was provided in the request,
+            or required fields are missing.
+    - 500 - Internal Server Error: Database query or execution failed.
     """
     request_data = request.get_json()
     if not request_data:
@@ -163,19 +169,26 @@ def edit_publication_collection(project, collection_id):
     """
     Edit a publication collection in the specified project by updating its fields.
 
-    Parameters:
-    - project (str): The name of the project.
-    - collection_id (str): The id of the publication collection to be updated. Must be a valid positive integer.
+    URL Path Parameters:
 
-    Optional POST data parameters in JSON format (at least one required):
+    - project (str): The name of the project.
+    - collection_id (str): The id of the publication collection to be updated.
+      Must be a valid positive integer.
+
+    POST Data Parameters in JSON Format (at least one required):
+
     - name (str or null): The name/title of the publication collection.
-    - published (int): The publication status. Must be an integer with values 0, 1 or 2.
+    - published (int): The publication status. Must be an integer with
+      values 0, 1 or 2.
     - deleted (int): Soft delete flag. Must be an integer with values 0 or 1.
 
     Returns:
-        JSON: A success message with the updated publication collection id, or an error message.
+
+        JSON: A success message with the updated publication collection id,
+        or an error message.
 
     Example Request:
+
         POST /projectname/publication_collection/456/edit/
         Body:
         {
@@ -184,20 +197,25 @@ def edit_publication_collection(project, collection_id):
         }
 
     Example Response (Success):
+
         {
             "msg": "Publication collection with id 456 updated successfully."
         }
 
     Example Response (Error):
+
         {
             "msg": "Field 'published' must be an integer with value 0, 1 or 2."
         }
 
     Status Codes:
-        200 - OK: The publication collection was updated successfully.
-        400 - Bad Request: Invalid collection_id, invalid field values, or no valid fields provided for the update.
-        404 - Not Found: No publication collection with the given collection_id exists or no changes were made.
-        500 - Internal Server Error: Database query or execution failed.
+
+    - 200 - OK: The publication collection was updated successfully.
+    - 400 - Bad Request: Invalid collection_id, invalid field values,
+            or no valid fields provided for the update.
+    - 404 - Not Found: No publication collection with the given collection_id
+            exists or no changes were made.
+    - 500 - Internal Server Error: Database query or execution failed.
     """
     # Verify that project is valid
     project_id = get_project_id_from_name(project)
@@ -418,27 +436,38 @@ def edit_publication(project, publication_id):
     """
     Edit a publication in the specified project by updating its fields.
 
-    Parameters:
-    - project (str): The name of the project.
-    - publication_id (str): The ID of the publication to be updated. Must be a valid integer.
+    URL Path Parameters:
 
-    Optional POST data parameters in JSON format (at least one required):
-    - publication_collection_id (int): The ID of the publication collection. Must be a positive integer.
-    - publication_comment_id (int): The ID of the publication comment. Must be a positive integer.
+    - project (str): The name of the project.
+    - publication_id (str): The ID of the publication to be updated.
+      Must be a valid integer.
+
+    POST Data Parameters in JSON Format (at least one required):
+
+    - publication_collection_id (int): The ID of the publication collection.
+      Must be a positive integer.
+    - publication_comment_id (int): The ID of the publication comment.
+      Must be a positive integer.
     - name (str): The name/title of the publication.
-    - original_filename (str): Path to the publication’s XML-file in the project GitHub repository.
-    - original_publication_date (str): The original publication date or year (formatted as a string).
-    - published (int): The publication status. Must be an integer with values 0, 1, or 2.
-    - language (str): The language code of the publication (ISO 639-1).
+    - original_filename (str): Path to the publication’s XML-file in the
+      project GitHub repository.
+    - original_publication_date (str): The original publication date or
+      year (formatted as a string).
+    - published (int): The publication status. Must be an integer with
+      values 0, 1 or 2.
+    - language (str): The language code of the main language of the
+      publication (ISO 639-1).
     - genre (str): The genre of the publication.
     - deleted (int): Soft delete flag. Must be an integer with values 0 or 1.
 
     Additionally, all POST data parameter values can be set to null, except 'deleted'.
 
     Returns:
+
         JSON: A success message if the publication was updated, or an error message.
 
     Example Request:
+
         POST /projectname/publication/123/edit/
         Body:
         {
@@ -448,20 +477,25 @@ def edit_publication(project, publication_id):
         }
 
     Example Response (Success):
+
         {
             "msg": "Publication with id 123 updated successfully."
         }
 
     Example Response (Error):
+
         {
             "msg": "Field 'published' must be an integer with value 0, 1 or 2."
         }
 
     Status Codes:
-        200 - OK: The publication was updated successfully.
-        400 - Bad Request: Invalid publication_id, invalid field values, or no valid fields provided for the update.
-        404 - Not Found: No publication with the given publication_id exists or no changes were made.
-        500 - Internal Server Error: Database query or execution failed.
+
+    - 200 - OK: The publication was updated successfully.
+    - 400 - Bad Request: Invalid publication_id, invalid field values,
+            or no valid fields provided for the update.
+    - 404 - Not Found: No publication with the given publication_id exists
+            or no changes were made.
+    - 500 - Internal Server Error: Database query or execution failed.
     """
     # Verify that publication_id is an integer
     publication_id = int_or_none(publication_id)
@@ -614,6 +648,8 @@ def add_manuscript(project, publication_id):
     """
     Takes "title", "filename", "published", "sort_order" as JSON data
     Returns "msg" and "manuscript_id" on success, otherwise 40x
+
+    Att! Use the "/<project>/publication/<publication_id>/link_file/" endpoint instead.
     """
     request_data = request.get_json()
     if not request_data:
@@ -708,6 +744,8 @@ def add_version(project, publication_id):
     Takes "title", "filename", "published", "sort_order", "type" as JSON data
     "type" denotes version type, 1=base text, 2=other variant
     Returns "msg" and "version_id" on success, otherwise 40x
+
+    Att! Use the "/<project>/publication/<publication_id>/link_file/" endpoint instead.
     """
     request_data = request.get_json()
     if not request_data:

--- a/sls_api/exceptions.py
+++ b/sls_api/exceptions.py
@@ -1,0 +1,10 @@
+class CascadeUpdateError(Exception):
+    """
+    Exception raised for errors in cascading updates to related tables.
+
+    Attributes:
+        message (str): Explanation of the error.
+    """
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message


### PR DESCRIPTION
This PR contains fixes to and refactoring of multiple tools-endpoints, mainly related to project, publication collection, publication comment/manuscript/version management.

The changes involve:

- Modifying which fields are editable and aligning the field names in POST data with the field names in the database.
- Using SQLAlchemy’s context manager to automatically handle commits and rollbacks.
- Using SQLAlchemy’s Core methods.
- Adding field and field value validation.
- Endpoints performing INSERT and UPDATE operations include the affected row(s) in the response.
- Standardising JSON responses for the tools-endpoints (see below).
- Adding a new endpoint (`list_user_projects` in `publishing.py`) for listing all projects the current user has access to.
- Adding a new endpoint (`list_project_subjects` in `events.py`) for listing all subjects in a given project.
- Adding detailed docstrings.

**BREAKING CHANGES**

- As mentioned field names in POST data have changed to align with the database field names.
- Fields in the responses of some endpoints have changed (see above about INSERT and UPDATE).
- The path of the `/<project>/publication/<publication_id>/link_file` endpoint has been changed to `/<project>/publication/<publication_id>/link_text/`.
- Two endpoints for adding a manuscript and a version respectively have been deleted. The `/<project>/publication/<publication_id>/link_text/` endpoint should be used instead.
- The endpoint for deleting a publication facsimile has been deleted. The endpoint for editing a facsimile should be used instead.
- JSON responses for all edited endpoints have been standardised. The responses always have the following structure now:

```
{
    "success": bool,
    "message": str,
    "data": object, array or null
}
```
- `success`: A boolean indicating whether the operation was successful.
- `message`: A string containing a descriptive message about the result.
- `data`: On success, an array of objects or an object with affected/retrieved data; `null` on error.