### PR TITLE
tools: remove redundant exception message in logger.exception calls

### DIFF
--- a/sls_api/endpoints/tools/collections.py
+++ b/sls_api/endpoints/tools/collections.py
@@ -172,8 +172,8 @@ def create_facsimile_collection(project):
                     status_code=201
                 )
 
-    except Exception as e:
-        logger.exception(f"Exception creating new facsimile collection: {str(e)}")
+    except Exception:
+        logger.exception("Exception creating new facsimile collection.")
         return create_error_response("Unexpected error: failed to create new facsimile collection.", 500)
 
 
@@ -346,8 +346,8 @@ def edit_facsimile_collection(project, collection_id):
                     data=updated_row._asdict()
                 )
 
-    except Exception as e:
-        logger.exception(f"Exception updating facsimile collection: {str(e)}")
+    except Exception:
+        logger.exception("Exception updating facsimile collection.")
         return create_error_response("Unexpected error: failed to update facsimile collection.", 500)
 
 
@@ -550,8 +550,8 @@ def list_facsimile_collections(project, order_by="id", direction="desc"):
                 data=[row._asdict() for row in rows]
             )
 
-    except Exception as e:
-        logger.exception(f"Exception retrieving facsimile collections: {str(e)}")
+    except Exception:
+        logger.exception("Exception retrieving facsimile collections.")
         return create_error_response("Unexpected error: failed to retrieve facsimile collections.", 500)
 
 
@@ -737,8 +737,8 @@ def link_facsimile_collection_to_publication(project, collection_id):
                     status_code=201
                 )
 
-    except Exception as e:
-        logger.exception(f"Exception creating new publication facsimile: {str(e)}")
+    except Exception:
+        logger.exception("Exception creating new publication facsimile.")
         return create_error_response("Unexpected error: failed to create new publication facsimile.", 500)
 
 
@@ -913,8 +913,8 @@ def edit_facsimile(project):
                     data=updated_row._asdict()
                 )
 
-    except Exception as e:
-        logger.exception(f"Exception updating publication facsimile: {str(e)}")
+    except Exception:
+        logger.exception("Exception updating publication facsimile.")
         return create_error_response("Unexpected error: failed to update publication facsimile.", 500)
 
 
@@ -1051,8 +1051,8 @@ def list_facsimile_collection_links(project, collection_id, order_by="id", direc
                 data=[row._asdict() for row in rows]
             )
 
-    except Exception as e:
-        logger.exception(f"Exception retrieving publication facsimiles: {str(e)}")
+    except Exception:
+        logger.exception("Exception retrieving publication facsimiles.")
         return create_error_response("Unexpected error: failed to retrieve publication facsimiles.", 500)
 
 
@@ -1179,8 +1179,8 @@ def list_publication_collections(project):
                 data=[row._asdict() for row in rows]
             )
 
-    except Exception as e:
-        logger.exception(f"Exception retrieving publication collections: {str(e)}")
+    except Exception:
+        logger.exception("Exception retrieving publication collections.")
         return create_error_response("Unexpected error: failed to retrieve publication collections.", 500)
 
 
@@ -1325,8 +1325,8 @@ def new_publication_collection(project):
                     status_code=201
                 )
 
-    except Exception as e:
-        logger.exception(f"Exception creating new publication collection: {str(e)}")
+    except Exception:
+        logger.exception("Exception creating new publication collection.")
         return create_error_response("Unexpected error: failed to create new publication collection.", 500)
 
 
@@ -1456,8 +1456,8 @@ def list_publications(project, collection_id, order_by="id"):
                     data=[row._asdict() for row in rows]
                 )
 
-    except Exception as e:
-        logger.exception(f"Exception retrieving publications: {str(e)}")
+    except Exception:
+        logger.exception("Exception retrieving publications.")
         return create_error_response("Unexpected error: failed to retrieve publications.", 500)
 
 
@@ -1664,6 +1664,6 @@ def new_publication(project, collection_id):
                     status_code=201
                 )
 
-    except Exception as e:
-        logger.exception(f"Exception creating new publication: {str(e)}")
+    except Exception:
+        logger.exception("Exception creating new publication.")
         return create_error_response("Unexpected error: failed to create new publication.", 500)

--- a/sls_api/endpoints/tools/events.py
+++ b/sls_api/endpoints/tools/events.py
@@ -303,8 +303,8 @@ def list_project_subjects(project, order_by="last_name", direction="asc"):
                 data=[row._asdict() for row in rows]
             )
 
-    except Exception as e:
-        logger.exception(f"Exception retrieving project subjects: {str(e)}")
+    except Exception:
+        logger.exception("Exception retrieving project subjects.")
         return create_error_response("Unexpected error: failed to retrieve person records in project.", 500)
 
 
@@ -490,8 +490,8 @@ def add_new_subject(project):
                     status_code=201
                 )
 
-    except Exception as e:
-        logger.exception(f"Exception creating new subject: {str(e)}")
+    except Exception:
+        logger.exception("Exception creating new subject.")
         return create_error_response("Unexpected error: failed to create new person record.", 500)
 
 
@@ -690,8 +690,8 @@ def edit_subject(project, subject_id):
                     data=updated_row._asdict()
                 )
 
-    except Exception as e:
-        logger.exception(f"Exception updating subject: {str(e)}")
+    except Exception:
+        logger.exception("Exception updating subject.")
         return create_error_response("Unexpected error: failed to update person record.", 500)
 
 
@@ -900,8 +900,8 @@ def add_new_translation(project):
                     status_code=201
                 )
 
-    except Exception as e:
-        logger.exception(f"Exception creating new translation: {str(e)}")
+    except Exception:
+        logger.exception("Exception creating new translation.")
         return create_error_response("Unexpected error: failed to create new translation.", 500)
 
 
@@ -1075,8 +1075,8 @@ def edit_translation(project, translation_id):
                             status_code=201
                         )
 
-                    except Exception as e:
-                        logger.exception(f"Exception creating new translation text: {str(e)}")
+                    except Exception:
+                        logger.exception("Exception creating new translation text.")
                         return create_error_response("Unexpected error: failed to create new translation text.", 500)
 
                 else:
@@ -1106,8 +1106,8 @@ def edit_translation(project, translation_id):
                         data=updated_row._asdict()
                     )
 
-    except Exception as e:
-        logger.exception(f"Exception updating translation text: {str(e)}")
+    except Exception:
+        logger.exception("Exception updating translation text.")
         return create_error_response("Unexpected error: failed to update translation text.", 500)
 
 
@@ -1258,8 +1258,8 @@ def list_translations(project, translation_id):
                     data=[row._asdict() for row in rows]
                 )
 
-    except Exception as e:
-        logger.exception(f"Exception retrieving translations: {str(e)}")
+    except Exception:
+        logger.exception("Exception retrieving translations.")
         return create_error_response("Unexpected error: failed to retrieve translations.", 500)
 
 

--- a/sls_api/endpoints/tools/publications.py
+++ b/sls_api/endpoints/tools/publications.py
@@ -135,8 +135,8 @@ def get_publications(project, order_by="id", direction="asc"):
                 data=[row._asdict() for row in rows]
             )
 
-    except Exception as e:
-        logger.exception(f"Exception retrieving publications: {str(e)}")
+    except Exception:
+        logger.exception("Exception retrieving publications.")
         return create_error_response("Unexpected error: failed to retrieve publications.", 500)
 
 
@@ -246,8 +246,8 @@ def get_publication(project, publication_id):
                 data=result._asdict()
             )
 
-    except Exception as e:
-        logger.exception(f"Exception retrieving publication: {str(e)}")
+    except Exception:
+        logger.exception("Exception retrieving publication.")
         return create_error_response("Unexpected error: failed to retrieve publication.", 500)
 
 
@@ -356,8 +356,8 @@ def get_publication_versions(project, publication_id):
                 data=[row._asdict() for row in rows]
             )
 
-    except Exception as e:
-        logger.exception(f"Exception retrieving publication versions: {str(e)}")
+    except Exception:
+        logger.exception("Exception retrieving publication versions.")
         return create_error_response("Unexpected error: failed to retrieve publication versions.", 500)
 
 
@@ -467,8 +467,8 @@ def get_publication_manuscripts(project, publication_id):
                 data=[row._asdict() for row in rows]
             )
 
-    except Exception as e:
-        logger.exception(f"Exception retrieving publication manuscripts: {str(e)}")
+    except Exception:
+        logger.exception("Exception retrieving publication manuscripts.")
         return create_error_response("Unexpected error: failed to retrieve publication manuscripts.", 500)
 
 
@@ -573,8 +573,8 @@ def get_publication_tags(project, publication_id):
                 data=[row._asdict() for row in rows]
             )
 
-    except Exception as e:
-        logger.exception(f"Exception retrieving publication tags: {str(e)}")
+    except Exception:
+        logger.exception("Exception retrieving publication tags.")
         return create_error_response("Unexpected error: failed to retrieve publication tags.", 500)
 
 
@@ -691,8 +691,8 @@ def get_publication_facsimiles(project, publication_id):
                 data=[row._asdict() for row in rows]
             )
 
-    except Exception as e:
-        logger.exception(f"Exception retrieving publication facsimiles: {str(e)}")
+    except Exception:
+        logger.exception("Exception retrieving publication facsimiles.")
         return create_error_response("Unexpected error: failed to retrieve publication facsimiles.", 500)
 
 
@@ -803,8 +803,8 @@ def get_publication_comments(project, publication_id):
                 data=[row._asdict() for row in rows]
             )
 
-    except Exception as e:
-        logger.exception(f"Exception retrieving publication comments: {str(e)}")
+    except Exception:
+        logger.exception("Exception retrieving publication comments.")
         return create_error_response("Unexpected error: failed to retrieve publication comments.", 500)
 
 
@@ -1066,6 +1066,6 @@ def link_text_to_publication(project, publication_id):
                     status_code=201
                 )
 
-    except Exception as e:
-        logger.exception(f"Exception creating new publication {text_type}: {str(e)}")
+    except Exception:
+        logger.exception(f"Exception creating new publication {text_type}.")
         return create_error_response(f"Unexpected error: failed to create new publication {text_type}.", 500)

--- a/sls_api/endpoints/tools/publishing.py
+++ b/sls_api/endpoints/tools/publishing.py
@@ -98,8 +98,8 @@ def list_user_projects():
                 data=[row._asdict() for row in rows]
             )
 
-    except Exception as e:
-        logger.exception(f"Exception retrieving user projects: {str(e)}")
+    except Exception:
+        logger.exception("Exception retrieving user projects.")
         return create_error_response("Unexpected error: failed to retrieve user projects.", 500)
 
 
@@ -233,8 +233,8 @@ def add_new_project():
                     status_code=201
                 )
 
-    except Exception as e:
-        logger.exception(f"Exception creating new project: {str(e)}")
+    except Exception:
+        logger.exception("Exception creating new project.")
         return create_error_response("Unexpected error: failed to create new project.", 500)
 
 
@@ -372,8 +372,8 @@ def edit_project(project_id):
                     data=updated_row._asdict()
                 )
 
-    except Exception as e:
-        logger.exception(f"Exception updating project: {str(e)}")
+    except Exception:
+        logger.exception("Exception updating project.")
         return create_error_response("Unexpected error: failed to update project.", 500)
 
 
@@ -600,11 +600,11 @@ def edit_publication_collection(project, collection_id):
                 )
 
     except CascadeUpdateError as ce:
-        logger.exception(f"Error updating publication collection: {ce.message}")
+        logger.error(f"Error updating publication collection: {ce.message}")
         return create_error_response(f"Unexpected error: {ce.message}", 500)
 
-    except Exception as e:
-        logger.exception(f"Exception updating publication collection: {str(e)}")
+    except Exception:
+        logger.exception("Exception updating publication collection.")
         return create_error_response("Unexpected error: failed to update publication collection.", 500)
 
 
@@ -978,11 +978,11 @@ def edit_publication(project, publication_id):
                 )
 
     except CascadeUpdateError as ce:
-        logger.exception(f"Error updating publication: {ce.message}")
+        logger.error(f"Error updating publication: {ce.message}")
         return create_error_response(f"Unexpected error: {ce.message}", 500)
 
-    except Exception as e:
-        logger.exception(f"Exception updating publication: {str(e)}")
+    except Exception:
+        logger.exception("Exception updating publication.")
         return create_error_response("Unexpected error: failed to update publication.", 500)
 
 
@@ -1157,8 +1157,8 @@ def edit_comment(project, publication_id):
                     data=updated_row._asdict()
                 )
 
-    except Exception as e:
-        logger.exception(f"Exception updating publication comment: {str(e)}")
+    except Exception:
+        logger.exception("Exception updating publication comment.")
         return create_error_response("Unexpected error: failed to update publication comment.", 500)
 
 
@@ -1361,8 +1361,8 @@ def edit_manuscript(project, manuscript_id):
                     data=updated_row._asdict()
                 )
 
-    except Exception as e:
-        logger.exception(f"Exception updating publication manuscript: {str(e)}")
+    except Exception:
+        logger.exception("Exception updating publication manuscript.")
         return create_error_response("Unexpected error: failed to update publication manuscript.", 500)
 
 
@@ -1564,8 +1564,8 @@ def edit_version(project, version_id):
                     data=updated_row._asdict()
                 )
 
-    except Exception as e:
-        logger.exception(f"Exception updating publication version: {str(e)}")
+    except Exception:
+        logger.exception("Exception updating publication version.")
         return create_error_response("Unexpected error: failed to update publication version.", 500)
 
 


### PR DESCRIPTION
When using `exception()` to log errors the exception message and stack trace are automatically included.