### PR TITLE
tools: add endpoint for getting publication metadata from xml

### DIFF
--- a/sls_api/configs/digital_editions_example.yml
+++ b/sls_api/configs/digital_editions_example.yml
@@ -31,6 +31,9 @@ parland:
     # Currently only used to set response headers on downloadable PDFs and
     # EPUBs in the `get_pdf_file` endpoint in `endpoints/media.py`.
     allowed_cors_origins: ["https://parland.sls.fi"]
+    # Max size in MB of XML files to be parsed. Currently only used in the
+    # `get_metadata_from_xml_file` endpoint in `endpoints/tools/files.py`.
+    xml_max_file_size: 5
 
 topelius:
     # First, settings about how the publication tools should communicate towards git
@@ -53,6 +56,9 @@ topelius:
     # Currently only used to set response headers on downloadable PDFs and
     # EPUBs in the `get_pdf_file` endpoint in `endpoints/media.py`.
     allowed_cors_origins: ["https://topelius.sls.fi"]
+    # Max size in MB of XML files to be parsed. Currently only used in the
+    # `get_metadata_from_xml_file` endpoint in `endpoints/tools/files.py`.
+    xml_max_file_size: 5
 
 # XML-to-HTML is somewhat computationally expensive, so HTML reading texts are cached for up to this amount of time
 cache_lifetime_seconds: 7200  # 2 hours

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -1,5 +1,6 @@
 import calendar
 from collections import OrderedDict
+from datetime import datetime
 from flask import jsonify, Response
 from flask_jwt_extended import get_jwt_identity, verify_jwt_in_request
 from functools import wraps
@@ -807,3 +808,73 @@ def handle_deleted_flag(values: Dict[str, Any]) -> Dict[str, Any]:
     if values.get("deleted"):
         values["published"] = 0
     return values
+
+
+def is_valid_year_yearmonth_or_date(date_string: str) -> bool:
+    """
+    Validates if a given string conforms to either 'YYYY', 'YYYY-MM' or
+    'YYYY-MM-DD' date formats and checks if it represents a logically
+    valid year, year-month or date.
+
+    Parameters:
+
+        date_string (str): The input string to be checked.
+
+    Returns:
+
+        bool: True if the string is a valid 'YYYY', 'YYYY-MM' or
+        'YYYY-MM-DD' format and represents a logically correct year,
+        year-month or date; False otherwise.
+
+    Examples:
+
+        >>> is_valid_year_yearmonth_or_date("2023")
+        True
+        >>> is_valid_year_yearmonth_or_date("2023-10")
+        True
+        >>> is_valid_year_yearmonth_or_date("2023-10-31")
+        True
+        >>> is_valid_year_yearmonth_or_date("2023-02-29")
+        False  # 2023 is not a leap year
+        >>> is_valid_year_yearmonth_or_date("2023-13-31")
+        False  # Invalid month
+        >>> is_valid_year_yearmonth_or_date("23-10-31")
+        False  # Invalid format
+    """
+    # Check for YYYY format
+    if len(date_string) == 4 and date_string.isdigit():
+        try:
+            datetime.strptime(date_string, "%Y")
+            return True
+        except ValueError:
+            return False
+
+    # Check for YYYY-MM format
+    elif (
+        len(date_string) == 7
+        and date_string[:4].isdigit()
+        and date_string[5:7].isdigit()
+        and date_string[4] == '-'
+    ):
+        try:
+            datetime.strptime(date_string, "%Y-%m")
+            return True
+        except ValueError:
+            return False
+
+    # Check for YYYY-MM-DD format
+    elif (
+        len(date_string) == 10
+        and date_string[:4].isdigit()
+        and date_string[5:7].isdigit()
+        and date_string[8:10].isdigit()
+        and date_string[4] == '-'
+        and date_string[7] == '-'
+    ):
+        try:
+            datetime.strptime(date_string, "%Y-%m-%d")
+            return True
+        except ValueError:
+            return False
+
+    return False

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -896,3 +896,32 @@ def is_valid_year_month(date_string: str) -> bool:
         return True
     except ValueError:
         return False
+
+
+def is_any_valid_date_format(date_string: str) -> bool:
+    """
+    Validates if a given string conforms to any of the following date
+    formats:
+
+    - 'YYYY': four-digit year between 1 and 9999, also valid for
+      non-zero-padded years before 1000.
+    - 'YYYY-MM'
+    - 'YYYY-MM-DD'
+
+    Parameters:
+
+        date_string (str): The input string to be checked.
+
+    Returns:
+
+        bool: True if the string is in any of the valid date formats;
+        False otherwise.
+    """
+    if (
+        is_valid_year(date_string)
+        or is_valid_date(date_string)
+        or is_valid_year_month(date_string)
+    ):
+        return True
+
+    return False

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -875,8 +875,6 @@ def is_valid_year_month(date_string: str) -> bool:
     Validates if a given string conforms to the 'YYYY-MM' date format.
     If the YYYY part is a year before 1000, it must be zero-padded.
 
-    Depends on the `is_valid_year()` helper function.
-
     Parameters:
 
         date_string (str): The input string to be checked.
@@ -893,12 +891,8 @@ def is_valid_year_month(date_string: str) -> bool:
         >>> is_valid_year_month("2023-13")
         False  # Invalid month
     """
-    parts = date_string.split("-")
-    if len(parts) == 2 and len(parts[0]) == 4 and is_valid_year(parts[0]):
-        try:
-            month = int(parts[1])
-            return 1 <= month <= 12
-        except ValueError:
-            return False
-
-    return False
+    try:
+        datetime.strptime(date_string, "%Y-%m")
+        return True
+    except ValueError:
+        return False

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -841,7 +841,7 @@ def is_valid_year(year_string: str) -> bool:
 def is_valid_date(date_string: str) -> bool:
     """
     Validates if a given string conforms to the 'YYYY-MM-DD' date format
-    and checks if it represents a logically date.
+    and checks if it represents a sensible date.
 
     Parameters:
 

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -815,7 +815,7 @@ def handle_deleted_flag(values: Dict[str, Any]) -> Dict[str, Any]:
 def is_valid_year(year_string: str) -> bool:
     """
     Checks if a string can be parsed as a four-digit year between 1 and 9999.
-    
+
     The function validates that the input string consists of only digits and
     represents a year between 1 and 9999. It handles both zero-padded and
     non-zero-padded formats for years less than 1000 (e.g., "0456" and "456"

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -832,7 +832,7 @@ def is_valid_year(year_string: str) -> bool:
     """
     if not year_string.isdigit():
         return False
-    
+
     # Check if the integer value is between 1 and 9999
     year = int(year_string)
     return 1 <= year <= 9999

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -812,11 +812,36 @@ def handle_deleted_flag(values: Dict[str, Any]) -> Dict[str, Any]:
     return values
 
 
-def is_valid_year_yearmonth_or_date(date_string: str) -> bool:
+def is_valid_year(year_string: str) -> bool:
     """
-    Validates if a given string conforms to either 'YYYY', 'YYYY-MM' or
-    'YYYY-MM-DD' date formats and checks if it represents a logically
-    valid year, year-month or date.
+    Checks if a string can be parsed as a four-digit year between 1 and 9999.
+    
+    The function validates that the input string consists of only digits and
+    represents a year between 1 and 9999. It handles both zero-padded and
+    non-zero-padded formats for years less than 1000 (e.g., "0456" and "456"
+    are both valid).
+
+    Args:
+
+        year_string (str): The input string representing a year.
+
+    Returns:
+
+        bool: True if the string represents a valid year between 1 and 9999,
+        False otherwise.
+    """
+    if not year_string.isdigit():
+        return False
+    
+    # Check if the integer value is between 1 and 9999
+    year = int(year_string)
+    return 1 <= year <= 9999
+
+
+def is_valid_date(date_string: str) -> bool:
+    """
+    Validates if a given string conforms to the 'YYYY-MM-DD' date format
+    and checks if it represents a logically date.
 
     Parameters:
 
@@ -824,58 +849,55 @@ def is_valid_year_yearmonth_or_date(date_string: str) -> bool:
 
     Returns:
 
-        bool: True if the string is a valid 'YYYY', 'YYYY-MM' or
-        'YYYY-MM-DD' format and represents a logically correct year,
-        year-month or date; False otherwise.
+        bool: True if the string is a valid 'YYYY-MM-DD' date format and
+        represents a logically correct date; False otherwise.
 
     Examples:
 
-        >>> is_valid_year_yearmonth_or_date("2023")
+        >>> is_valid_date("2023-10-31")
         True
-        >>> is_valid_year_yearmonth_or_date("2023-10")
-        True
-        >>> is_valid_year_yearmonth_or_date("2023-10-31")
-        True
-        >>> is_valid_year_yearmonth_or_date("2023-02-29")
+        >>> is_valid_date("2023-02-29")
         False  # 2023 is not a leap year
-        >>> is_valid_year_yearmonth_or_date("2023-13-31")
+        >>> is_valid_date("2023-13-31")
         False  # Invalid month
-        >>> is_valid_year_yearmonth_or_date("23-10-31")
+        >>> is_valid_date("23-10-31")
         False  # Invalid format
     """
-    # Check for YYYY format
-    if len(date_string) == 4 and date_string.isdigit():
-        try:
-            datetime.strptime(date_string, "%Y")
-            return True
-        except ValueError:
-            return False
+    try:
+        datetime.strptime(date_string, "%Y-%m-%d")
+        return True
+    except ValueError:
+        return False
 
-    # Check for YYYY-MM format
-    elif (
-        len(date_string) == 7
-        and date_string[:4].isdigit()
-        and date_string[5:7].isdigit()
-        and date_string[4] == '-'
-    ):
-        try:
-            datetime.strptime(date_string, "%Y-%m")
-            return True
-        except ValueError:
-            return False
 
-    # Check for YYYY-MM-DD format
-    elif (
-        len(date_string) == 10
-        and date_string[:4].isdigit()
-        and date_string[5:7].isdigit()
-        and date_string[8:10].isdigit()
-        and date_string[4] == '-'
-        and date_string[7] == '-'
-    ):
+def is_valid_year_month(date_string: str) -> bool:
+    """
+    Validates if a given string conforms to the 'YYYY-MM' date format.
+    If the YYYY part is a year before 1000, it must be zero-padded.
+
+    Depends on the `is_valid_year()` helper function.
+
+    Parameters:
+
+        date_string (str): The input string to be checked.
+
+    Returns:
+
+        bool: True if the string is a valid 'YYYY-MM' format; False
+        otherwise.
+
+    Examples:
+
+        >>> is_valid_year_month("2023-10")
+        True
+        >>> is_valid_year_month("2023-13")
+        False  # Invalid month
+    """
+    parts = date_string.split("-")
+    if len(parts) == 2 and len(parts[0]) == 4 and is_valid_year(parts[0]):
         try:
-            datetime.strptime(date_string, "%Y-%m-%d")
-            return True
+            month = int(parts[1])
+            return 1 <= month <= 12
         except ValueError:
             return False
 

--- a/sls_api/endpoints/tools/files.py
+++ b/sls_api/endpoints/tools/files.py
@@ -12,7 +12,8 @@ from werkzeug.security import safe_join
 
 from sls_api.endpoints.generics import get_project_config, \
     project_permission_required, create_error_response, \
-    create_success_response, is_valid_year_yearmonth_or_date
+    create_success_response, is_valid_year, is_valid_date, \
+    is_valid_year_month
 
 
 file_tools = Blueprint("file_tools", __name__)
@@ -620,8 +621,12 @@ def extract_publication_metadata_from_tei_xml(file_path: str) -> Tuple[Optional[
             # Validate orig_date, must conform to YYYY, YYYY-MM
             # or YYYY-MM-DD date formats
             if (
-                orig_date is not None and
-                not is_valid_year_yearmonth_or_date(str(orig_date))
+                orig_date is not None
+                and not (
+                    is_valid_year(str(orig_date))
+                    or is_valid_year_month(str(orig_date))
+                    or is_valid_date(str(orig_date))
+                )
             ):
                 orig_date = None
 

--- a/sls_api/endpoints/tools/files.py
+++ b/sls_api/endpoints/tools/files.py
@@ -12,8 +12,7 @@ from werkzeug.security import safe_join
 
 from sls_api.endpoints.generics import get_project_config, \
     project_permission_required, create_error_response, \
-    create_success_response, is_valid_year, is_valid_date, \
-    is_valid_year_month
+    create_success_response, is_any_valid_date_format
 
 
 file_tools = Blueprint("file_tools", __name__)
@@ -621,11 +620,7 @@ def extract_publication_metadata_from_tei_xml(file_path: str) -> Tuple[Optional[
             # or YYYY-MM-DD date formats
             if (
                 orig_date is not None
-                and not (
-                    is_valid_year(str(orig_date))
-                    or is_valid_year_month(str(orig_date))
-                    or is_valid_date(str(orig_date))
-                )
+                and not is_any_valid_date_format(str(orig_date))
             ):
                 orig_date = None
 

--- a/sls_api/endpoints/tools/files.py
+++ b/sls_api/endpoints/tools/files.py
@@ -546,7 +546,12 @@ def get_metadata_from_xml_file(project: str, file_path: str):
         return create_error_response("Error: the file path must point to a file with a .xml extension.", 400)
 
     # Check file size so we don't parse overly large XML files
-    max_file_size = 5 * 1024 * 1024  # 5 MB
+    # Use default value if max size not specified in config
+    if "xml_max_file_size" in config:
+        max_file_size = config["xml_max_file_size"] * 1024 * 1024
+    else:
+        max_file_size = 5 * 1024 * 1024  # 5 MB
+
     if os.path.getsize(full_path) > max_file_size:
         return create_error_response("Error: file size exceeds the maximum allowed limit (5 MB).", 400)
 

--- a/sls_api/endpoints/tools/files.py
+++ b/sls_api/endpoints/tools/files.py
@@ -542,7 +542,7 @@ def get_metadata_from_xml_file(project: str, file_path: str):
         return create_error_response(f"Error accessing file at {file_path}", 500)
 
     # Check that the file has a .xml extension
-    if not full_path.endswith(".xml"):
+    if os.path.splitext(full_path) != ".xml":
         return create_error_response("Error: the file path must point to a file with a .xml extension.", 400)
 
     # Check file size so we don't parse overly large XML files

--- a/sls_api/endpoints/tools/files.py
+++ b/sls_api/endpoints/tools/files.py
@@ -530,14 +530,8 @@ def get_metadata_from_xml_file(project: str, file_path: str):
     if full_path is None:
         return create_error_response("Error: invalid file path.", 400)
 
-    # Resolve the real, absolute paths
-    base_dir = os.path.realpath(config["file_root"])
+    # Resolve the real, absolute path
     full_path = os.path.realpath(full_path)
-
-    # Verify that full_path is within base_dir, i.e. file_root specified
-    # in config
-    if os.path.commonpath([base_dir, full_path]) != base_dir:
-        return create_error_response("Error: invalid file path.", 400)
 
     # Check if the file exists
     try:

--- a/sls_api/endpoints/tools/files.py
+++ b/sls_api/endpoints/tools/files.py
@@ -456,7 +456,7 @@ def get_metadata_from_xml_file(project: str, file_path: str):
     This endpoint parses a TEI (Text Encoding Initiative) XML file
     specified by `file_path` within the given `project` and extracts
     publication metadata, including the title, original publication date
-    (date of origin), and language.
+    (date of origin), language, and genre.
 
     URL Path Parameters:
 
@@ -493,7 +493,8 @@ def get_metadata_from_xml_file(project: str, file_path: str):
             "data": {
                 "name": "Publication Title",
                 "original_publication_date": "1854-07-20",
-                "language": "en"
+                "language": "en",
+                "genre": "prose"
             }
         }
 
@@ -580,6 +581,7 @@ def extract_publication_metadata_from_tei_xml(file_path: str) -> Tuple[Optional[
             - "original_publication_date" (str or None): The date of
               origin in "YYYY", "YYYY-MM", or "YYYY-MM-DD" format.
             - "language" (str or None): The language code.
+            - "genre" (str or None): The genre of the text.
             Returns `None` if an error occurred.
         - error_message (str or None): An error message if an error
           occurred; otherwise `None`.
@@ -632,7 +634,8 @@ def extract_publication_metadata_from_tei_xml(file_path: str) -> Tuple[Optional[
         metadata = {
             "name": title,
             "original_publication_date": orig_date,
-            "language": language
+            "language": language,
+            "genre": None  # Currently, genre is not extractable from the XML files
         }
         return metadata, None, 200
 


### PR DESCRIPTION
This adds an endpoint that can be used to retrieve metadata from an XML file defined in the path provided as a URL path parameter.

This simplifies adding publications (and manuscripts and versions) to the database, when some of the required data (like text title and date of origin) for the database can be read from the XML file of the publication, and doesn't have to be manually inserted.

The code uses the Python ElementTree XML API for parsing.