### PR TITLE
tools: add endpoint to get project git repo details

### DIFF
--- a/sls_api/endpoints/tools/files.py
+++ b/sls_api/endpoints/tools/files.py
@@ -138,10 +138,10 @@ def get_git_repo_details(project):
 
     - `project` (str, required): The name of the project for which
       Git repository details are being retrieved.
-    
+
     Returns:
 
-    - A tuple containing a Flask Response object with JSON data and an 
+    - A tuple containing a Flask Response object with JSON data and an
       HTTP status code. The JSON response has the following structure:
 
         {

--- a/sls_api/endpoints/tools/files.py
+++ b/sls_api/endpoints/tools/files.py
@@ -123,7 +123,7 @@ def update_config(project):
         return jsonify({"msg": "received"})
 
 
-@file_tools.route("/<project>/git-repo-details/get")
+@file_tools.route("/<project>/git-repo-details")
 @project_permission_required
 def get_git_repo_details(project):
     """

--- a/sls_api/endpoints/tools/files.py
+++ b/sls_api/endpoints/tools/files.py
@@ -8,7 +8,8 @@ import os
 import subprocess
 from werkzeug.security import safe_join
 
-from sls_api.endpoints.generics import get_project_config, project_permission_required
+from sls_api.endpoints.generics import get_project_config, project_permission_required, \
+    create_error_response, create_success_response
 
 
 file_tools = Blueprint("file_tools", __name__)
@@ -120,6 +121,87 @@ def update_config(project):
         with open(file_path, "w") as f:
             json.dump(request_data, f)
         return jsonify({"msg": "received"})
+
+
+@file_tools.route("/<project>/git-repo-details/get")
+@project_permission_required
+def get_git_repo_details(project):
+    """
+    Retrieve details of a project's git repository.
+
+    This endpoint fetches and returns details of a git repository
+    associated with a given `project`, including the repository name
+    and current branch. The details are extracted from the project's
+    configuration on the server.
+
+    URL Path Parameters:
+
+    - `project` (str, required): The name of the project for which
+      Git repository details are being retrieved.
+    
+    Returns:
+
+    - A tuple containing a Flask Response object with JSON data and an 
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": object or null
+        }
+
+      - `success`: A boolean indicating whether the operation was successful.
+      - `message`: A string containing a descriptive message about the result.
+      - `data`: On success, an object containing the Git repository details;
+        `null` on error.
+
+    Example Request:
+
+        GET /my_project/git-repo-details/get
+
+    Example Success Response (HTTP 200):
+
+        {
+            "success": true,
+            "message": "Project git repository details successfully retrieved.",
+            "data": {
+                "name": "my_repo",
+                "branch": "main"
+            }
+        }
+
+    Example Error Response (HTTP 500):
+
+        {
+            "success": false,
+            "message": "Error: project config not found on the server.",
+            "data": null
+        }
+
+    Status Codes:
+
+    - 200 - OK: The request was successful, and the repository details are
+            returned.
+    - 404 - Not Found: The project configuration does not exist.
+    - 500 - Internal Server Error: An unexpected error occurred on the
+            server.
+    """
+    # Validate project config
+    config = get_project_config(project)
+    if config is None:
+        return create_error_response("Error: project config not found on the server.", 404)
+
+    config_ok = check_project_config(project)
+    if not config_ok[0]:
+        return create_error_response(f"Error: {config_ok[1]}", 404)
+
+    # Get the repo name from the repo URL
+    repo_name = str(config["git_repository"]).split('/')[-1].replace(".git", "")
+
+    return create_success_response(
+        message="Project git repository details successfully retrieved.",
+        data={"name": repo_name, "branch": config["git_branch"]}
+    )
 
 
 @file_tools.route("/<project>/sync_files/", methods=["POST"])


### PR DESCRIPTION
The endpoint returns the projects git repository name and current branch. This can be useful to display in the CMS frontend.