### PR TITLE
tools: extract "genre" metadata from TEI XML and improve "date" extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,6 @@
 __pycache__
 .DS_Store
 .vs
-build
-venv
 configs/digital_editions.yml
 sls_api/scripts/xslt/*
 sls_api/scripts/get-pip.py

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 __pycache__
 .DS_Store
 .vs
+build
+venv
 configs/digital_editions.yml
 sls_api/scripts/xslt/*
 sls_api/scripts/get-pip.py


### PR DESCRIPTION
Modifies the tools-endpoint for extracting metadata from TEI XML documents in two ways:

1. "genre" now supported.
2. "original_publication_date" can be extracted from a separate element for correspondence. Also fixes validation of the date, which wasn't always applied previously.