### PR TITLE
publisher: add XSLT processing option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         'raven[flask]==6.10.0',
         'ruamel.yaml==0.18.6',
         'requests==2.32.3',
+        'saxonche==12.5.0',
         'sqlalchemy==2.0.36',
         'werkzeug==3.1.3',
         'uwsgi==2.0.28'

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -628,8 +628,23 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
                                 md5sums.append(calculate_checksum(com_target_file_path))
                             else:
                                 md5sums.append("SKIP")
-                            generate_est_and_com_files(row, project, est_source_file_path, com_source_file_path,
-                                                       est_target_file_path, com_target_file_path)
+
+                            if modern_text_encoding:
+                                generate_modern_est_and_com_files(row,
+                                                                  project,
+                                                                  est_source_file_path,
+                                                                  com_source_file_path,
+                                                                  est_target_file_path,
+                                                                  com_target_file_path,
+                                                                  saxon_proc,
+                                                                  xslt_execs)
+                            else:
+                                generate_est_and_com_files(row,
+                                                           project,
+                                                           est_source_file_path,
+                                                           com_source_file_path,
+                                                           est_target_file_path,
+                                                           com_target_file_path)
                         except Exception:
                             logger.exception("Failed to generate est/com files for publication {}!".format(publication_id))
                             continue
@@ -657,8 +672,23 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
                                     md5sums.append(calculate_checksum(com_target_file_path))
                                 else:
                                     md5sums.append("SKIP")
-                                generate_est_and_com_files(row, project, est_source_file_path, com_source_file_path,
-                                                           est_target_file_path, com_target_file_path)
+
+                                if modern_text_encoding:
+                                    generate_modern_est_and_com_files(row,
+                                                                      project,
+                                                                      est_source_file_path,
+                                                                      com_source_file_path,
+                                                                      est_target_file_path,
+                                                                      com_target_file_path,
+                                                                      saxon_proc,
+                                                                      xslt_execs)
+                                else:
+                                    generate_est_and_com_files(row,
+                                                               project,
+                                                               est_source_file_path,
+                                                               com_source_file_path,
+                                                               est_target_file_path,
+                                                               com_target_file_path)
                             except Exception:
                                 logger.exception("Failed to generate est/com files for publication {}!".format(publication_id))
                                 continue

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -1037,7 +1037,7 @@ if __name__ == "__main__":
     parser.add_argument("--git_author", type=str, help="Author used for git commits (Default 'Publisher <is@sls.fi>')", default="Publisher <is@sls.fi>")
     parser.add_argument("--no_git", action="store_true", help="Don't run git commands as part of publishing.")
     parser.add_argument("--is_multilingual", action="store_true", help="The publication is multilingual and original_filename is found in translation_text")
-    parser.add_argument("--use_xslt_processing", action="store_true", help="XML files related to the publication are processed using XSLT.")
+    parser.add_argument("--use_xslt_processing", action="store_true", help="XML files related to the publication are processed using project specific XSLT.")
 
     args = parser.parse_args()
 

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -183,7 +183,7 @@ def construct_notes_xml(comments: List[Dict[str, Any]], comment_positions: Dict[
     """
     Given a list of dictionaries with comment notes data and a dictionary
     with note IDs (keys) and note positions (values), constructs an XML
-    fragment of the notes and returns it in stringified form. 
+    fragment of the notes and returns it in stringified form.
     """
     notes = []
     for comment in comments:

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -640,13 +640,13 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
 
                         if use_xslt_processing:
                             generate_est_and_com_files_with_xslt(row,
-                                                              project,
-                                                              est_source_file_path,
-                                                              com_source_file_path,
-                                                              est_target_file_path,
-                                                              com_target_file_path,
-                                                              saxon_proc,
-                                                              xslt_execs)
+                                                                 project,
+                                                                 est_source_file_path,
+                                                                 com_source_file_path,
+                                                                 est_target_file_path,
+                                                                 com_target_file_path,
+                                                                 saxon_proc,
+                                                                 xslt_execs)
                         else:
                             generate_est_and_com_files(row,
                                                        project,
@@ -689,13 +689,13 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
 
                             if use_xslt_processing:
                                 generate_est_and_com_files_with_xslt(row,
-                                                                  project,
-                                                                  est_source_file_path,
-                                                                  com_source_file_path,
-                                                                  est_target_file_path,
-                                                                  com_target_file_path,
-                                                                  saxon_proc,
-                                                                  xslt_execs)
+                                                                     project,
+                                                                     est_source_file_path,
+                                                                     com_source_file_path,
+                                                                     est_target_file_path,
+                                                                     com_target_file_path,
+                                                                     saxon_proc,
+                                                                     xslt_execs)
                             else:
                                 generate_est_and_com_files(row,
                                                            project,
@@ -733,13 +733,13 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
 
                                 if use_xslt_processing:
                                     generate_est_and_com_files_with_xslt(row,
-                                                                      project,
-                                                                      est_source_file_path,
-                                                                      com_source_file_path,
-                                                                      est_target_file_path,
-                                                                      com_target_file_path,
-                                                                      saxon_proc,
-                                                                      xslt_execs)
+                                                                         project,
+                                                                         est_source_file_path,
+                                                                         com_source_file_path,
+                                                                         est_target_file_path,
+                                                                         com_target_file_path,
+                                                                         saxon_proc,
+                                                                         xslt_execs)
                                 else:
                                     generate_est_and_com_files(row,
                                                                project,
@@ -933,10 +933,10 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
 
                         if use_xslt_processing:
                             generate_ms_file_with_xslt(row,
-                                                    source_file_path,
-                                                    target_file_path,
-                                                    saxon_proc,
-                                                    xslt_execs)
+                                                       source_file_path,
+                                                       target_file_path,
+                                                       saxon_proc,
+                                                       xslt_execs)
                         else:
                             generate_ms_file(source_file_path,
                                              target_file_path,
@@ -966,10 +966,10 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
 
                             if use_xslt_processing:
                                 generate_ms_file_with_xslt(row,
-                                                        source_file_path,
-                                                        target_file_path,
-                                                        saxon_proc,
-                                                        xslt_execs)
+                                                           source_file_path,
+                                                           target_file_path,
+                                                           saxon_proc,
+                                                           xslt_execs)
                             else:
                                 generate_ms_file(source_file_path,
                                                  target_file_path,
@@ -995,10 +995,10 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
 
                                 if use_xslt_processing:
                                     generate_ms_file_with_xslt(row,
-                                                            source_file_path,
-                                                            target_file_path,
-                                                            saxon_proc,
-                                                            xslt_execs)
+                                                               source_file_path,
+                                                               target_file_path,
+                                                               saxon_proc,
+                                                               xslt_execs)
                                 else:
                                     generate_ms_file(source_file_path,
                                                      target_file_path,
@@ -1060,7 +1060,8 @@ if __name__ == "__main__":
         else:
             if args.project in valid_projects:
                 check_publication_mtimes_and_publish_files(args.project, ids, git_author=args.git_author,
-                                                           no_git=args.no_git, force_publish=args.all_ids, is_multilingual=args.is_multilingual,
+                                                           no_git=args.no_git, force_publish=args.all_ids,
+                                                           is_multilingual=args.is_multilingual,
                                                            use_xslt_processing=args.use_xslt_processing)
             else:
                 logger.error(f"{args.project} is not in the API configuration or lacks 'comments_database' setting, aborting...")

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -240,7 +240,7 @@ def compile_xslt_stylesheets(
                 xslt_execs[type_key] = None
         else:
             xslt_execs[type_key] = None
-    
+
     return xslt_execs
 
 

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -308,7 +308,7 @@ def generate_modern_est_and_com_files(publication_info: Optional[Dict[str, Any]]
 
         notes_xml_str = "\n".join(note_fragments)
 
-    try: 
+    try:
         com_document = SaxonXMLDocument(saxon_proc, xml_filepath=com_source_file_path)
         if est_metadata:
             com_metadata = est_metadata
@@ -554,7 +554,8 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
                         else:
                             md5sums.append("SKIP")
                         if modern_text_encoding:
-                            generate_modern_est_and_com_files(row, project,
+                            generate_modern_est_and_com_files(row,
+                                                              project,
                                                               est_source_file_path,
                                                               com_source_file_path,
                                                               est_target_file_path,
@@ -563,8 +564,12 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
                                                               xslt_est_exec,
                                                               xslt_com_exec)
                         else:
-                            generate_est_and_com_files(row, project, est_source_file_path, com_source_file_path,
-                                                   est_target_file_path, com_target_file_path)
+                            generate_est_and_com_files(row,
+                                                       project,
+                                                       est_source_file_path,
+                                                       com_source_file_path,
+                                                       est_target_file_path,
+                                                       com_target_file_path)
                     except Exception:
                         logger.exception("Failed to generate est/com files for publication {}!".format(publication_id))
                         continue

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -287,6 +287,8 @@ def generate_est_and_com_files_with_xslt(publication_info: Optional[Dict[str, An
     else:
         try:
             est_document = SaxonXMLDocument(saxon_proc, xml_filepath=est_source_file_path)
+            # Create a dictionary with publication metadata which will be
+            # passed as a parameter to the XSLT processor.
             est_params = {}
             if publication_info is not None:
                 est_params = {
@@ -344,6 +346,8 @@ def generate_est_and_com_files_with_xslt(publication_info: Optional[Dict[str, An
 
     try:
         com_document = SaxonXMLDocument(saxon_proc, xml_filepath=com_source_file_path)
+        # Create a dictionary with publication comment metadata which will be
+        # passed as a parameter to the XSLT processor.
         if est_params:
             com_params = est_params
             com_params["commentId"] = publication_info["publication_comment_id"]
@@ -409,6 +413,8 @@ def generate_ms_file_with_xslt(publication_info: Optional[Dict[str, Any]],
             raise ValueError("XSLT executable for 'ms' is missing.")
 
         ms_document = SaxonXMLDocument(saxon_proc, xml_filepath=source_file_path)
+        # Create a dictionary with publication manuscript metadata which will be
+        # passed as a parameter to the XSLT processor.
         ms_params = {}
         if publication_info is not None:
             ms_params = {

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -317,7 +317,7 @@ def generate_modern_est_and_com_files(publication_info: Optional[Dict[str, Any]]
         else:
             com_metadata = {}
         com_metadata["textType"] = "com"
-        com_metadata["notesXML"] = notes_xml_str
+        com_metadata["notes"] = notes_xml_str
 
         com_document.generate_web_xml_file(xslt_exec=xslt_com_exec,
                                            output_filepath=com_target_file_path,

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -845,8 +845,6 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
                 target_filename = "{}_{}_ms_{}.xml".format(collection_id,
                                                            publication_id,
                                                            manuscript_id)
-                if row["original_filename"] is None:
-                    continue
 
                 source_filename = row["original_filename"]
                 if not source_filename:

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -301,9 +301,9 @@ def generate_est_and_com_files_with_xslt(publication_info: Optional[Dict[str, An
                 }
             est_params["textType"] = "est"
 
-            est_document.generate_web_xml_file(xslt_exec=xslt_execs["est"],
-                                               output_filepath=est_target_file_path,
-                                               parameters=est_params)
+            est_document.transform_and_save(xslt_exec=xslt_execs["est"],
+                                            output_filepath=est_target_file_path,
+                                            parameters=est_params)
         except Exception:
             logger.exception(f"Failed to handle est master file: {est_source_file_path}")
             raise
@@ -353,9 +353,9 @@ def generate_est_and_com_files_with_xslt(publication_info: Optional[Dict[str, An
         com_params["textType"] = "com"
         com_params["notes"] = notes_xml_str
 
-        com_document.generate_web_xml_file(xslt_exec=xslt_execs["com"],
-                                           output_filepath=com_target_file_path,
-                                           parameters=com_params)
+        com_document.transform_and_save(xslt_exec=xslt_execs["com"],
+                                        output_filepath=com_target_file_path,
+                                        parameters=com_params)
     except Exception:
         logger.exception(f"Failed to handle com master file: {com_source_file_path}")
         raise
@@ -424,9 +424,9 @@ def generate_ms_file_with_xslt(publication_info: Optional[Dict[str, Any]],
             }
         ms_params["textType"] = "ms"
 
-        ms_document.generate_web_xml_file(xslt_exec=xslt_execs["ms"],
-                                          output_filepath=target_file_path,
-                                          parameters=ms_params)
+        ms_document.transform_and_save(xslt_exec=xslt_execs["ms"],
+                                       output_filepath=target_file_path,
+                                       parameters=ms_params)
     except Exception:
         logger.exception(f"Failed to handle manuscript file: {source_file_path}")
         raise

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -635,8 +635,8 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
                     logger.info("Comment file not set for publication {}, using template instead.".format(publication_id))
                     comment_file = COMMENTS_TEMPLATE_PATH_IN_FILE_ROOT
 
-                # Add the comment filename and published status to the row
-                # dict so it can be passed to called functions
+                # Add the comment filename to the row dict so it can be passed
+                # to called functions
                 row["com_original_filename"] = comment_file
 
                 com_source_file_path = os.path.join(file_root, comment_file)

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -268,14 +268,14 @@ def generate_est_and_com_files(publication_info, project, est_master_file_path, 
         raise ex
 
 
-def generate_modern_est_and_com_files(publication_info: Optional[Dict[str, Any]],
-                                      project: str,
-                                      est_source_file_path: str,
-                                      com_source_file_path: str,
-                                      est_target_file_path: str,
-                                      com_target_file_path: str,
-                                      saxon_proc: PySaxonProcessor,
-                                      xslt_execs: Dict[str, Optional[PyXsltExecutable]]):
+def generate_est_and_com_files_with_xslt(publication_info: Optional[Dict[str, Any]],
+                                         project: str,
+                                         est_source_file_path: str,
+                                         com_source_file_path: str,
+                                         est_target_file_path: str,
+                                         com_target_file_path: str,
+                                         saxon_proc: PySaxonProcessor,
+                                         xslt_execs: Dict[str, Optional[PyXsltExecutable]]):
     """
     Generates published est and com files using XSLT processing.
     """
@@ -302,8 +302,8 @@ def generate_modern_est_and_com_files(publication_info: Optional[Dict[str, Any]]
             est_params["textType"] = "est"
 
             est_document.generate_web_xml_file(xslt_exec=xslt_execs["est"],
-                                            output_filepath=est_target_file_path,
-                                            parameters=est_params)
+                                               output_filepath=est_target_file_path,
+                                               parameters=est_params)
         except Exception:
             logger.exception(f"Failed to handle est master file: {est_source_file_path}")
             raise
@@ -395,11 +395,11 @@ def generate_ms_file(master_file_path, target_file_path, publication_info):
     ms_document.Save(target_file_path)
 
 
-def generate_modern_ms_file(publication_info: Optional[Dict[str, Any]],
-                            source_file_path: str,
-                            target_file_path: str,
-                            saxon_proc: PySaxonProcessor,
-                            xslt_execs: Dict[str, Optional[PyXsltExecutable]]):
+def generate_ms_file_with_xslt(publication_info: Optional[Dict[str, Any]],
+                               source_file_path: str,
+                               target_file_path: str,
+                               saxon_proc: PySaxonProcessor,
+                               xslt_execs: Dict[str, Optional[PyXsltExecutable]]):
     """
     Generates a published ms file using XSLT processing.
     """
@@ -432,7 +432,7 @@ def generate_modern_ms_file(publication_info: Optional[Dict[str, Any]],
         raise
 
 
-def check_publication_mtimes_and_publish_files(project: str, publication_ids: Union[tuple, None], git_author: str, no_git=False, force_publish=False, is_multilingual=False, modern_text_encoding=False):
+def check_publication_mtimes_and_publish_files(project: str, publication_ids: Union[tuple, None], git_author: str, no_git=False, force_publish=False, is_multilingual=False, use_xslt_processing=False):
     update_success, result_str = update_files_in_git_repo(project)
     if not update_success:
         logger.error("Git update failed! Reason: {}".format(result_str))
@@ -549,7 +549,7 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
             # close DB connection for now, it won't be needed for a while
             connection.close()
 
-            if modern_text_encoding:
+            if use_xslt_processing:
                 # Compile Saxon XSLT stylesheets so they can be reused for
                 # each publication
                 saxon_proc: PySaxonProcessor = PySaxonProcessor(license=False)
@@ -638,8 +638,8 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
                         else:
                             md5sums.append("SKIP")
 
-                        if modern_text_encoding:
-                            generate_modern_est_and_com_files(row,
+                        if use_xslt_processing:
+                            generate_est_and_com_files_with_xslt(row,
                                                               project,
                                                               est_source_file_path,
                                                               com_source_file_path,
@@ -687,8 +687,8 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
                             else:
                                 md5sums.append("SKIP")
 
-                            if modern_text_encoding:
-                                generate_modern_est_and_com_files(row,
+                            if use_xslt_processing:
+                                generate_est_and_com_files_with_xslt(row,
                                                                   project,
                                                                   est_source_file_path,
                                                                   com_source_file_path,
@@ -731,8 +731,8 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
                                 else:
                                     md5sums.append("SKIP")
 
-                                if modern_text_encoding:
-                                    generate_modern_est_and_com_files(row,
+                                if use_xslt_processing:
+                                    generate_est_and_com_files_with_xslt(row,
                                                                       project,
                                                                       est_source_file_path,
                                                                       com_source_file_path,
@@ -931,8 +931,8 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
                         else:
                             md5sum = "SKIP"
 
-                        if modern_text_encoding:
-                            generate_modern_ms_file(row,
+                        if use_xslt_processing:
+                            generate_ms_file_with_xslt(row,
                                                     source_file_path,
                                                     target_file_path,
                                                     saxon_proc,
@@ -964,8 +964,8 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
                             else:
                                 md5sum = "SKIP"
 
-                            if modern_text_encoding:
-                                generate_modern_ms_file(row,
+                            if use_xslt_processing:
+                                generate_ms_file_with_xslt(row,
                                                         source_file_path,
                                                         target_file_path,
                                                         saxon_proc,
@@ -993,8 +993,8 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
                                 else:
                                     md5sum = "SKIP"
 
-                                if modern_text_encoding:
-                                    generate_modern_ms_file(row,
+                                if use_xslt_processing:
+                                    generate_ms_file_with_xslt(row,
                                                             source_file_path,
                                                             target_file_path,
                                                             saxon_proc,
@@ -1037,7 +1037,7 @@ if __name__ == "__main__":
     parser.add_argument("--git_author", type=str, help="Author used for git commits (Default 'Publisher <is@sls.fi>')", default="Publisher <is@sls.fi>")
     parser.add_argument("--no_git", action="store_true", help="Don't run git commands as part of publishing.")
     parser.add_argument("--is_multilingual", action="store_true", help="The publication is multilingual and original_filename is found in translation_text")
-    parser.add_argument("--modern_text_encoding", action="store_true", help="The publication is encoded according to the modern SLS text encoding guidelines and is processed differently from legacy encoded publications.")
+    parser.add_argument("--use_xslt_processing", action="store_true", help="XML files related to the publication are processed using XSLT.")
 
     args = parser.parse_args()
 
@@ -1056,12 +1056,12 @@ if __name__ == "__main__":
             for p in valid_projects:
                 check_publication_mtimes_and_publish_files(p, ids, git_author=args.git_author,
                                                            no_git=args.no_git, force_publish=args.all_ids,
-                                                           modern_text_encoding=args.modern_text_encoding)
+                                                           use_xslt_processing=args.use_xslt_processing)
         else:
             if args.project in valid_projects:
                 check_publication_mtimes_and_publish_files(args.project, ids, git_author=args.git_author,
                                                            no_git=args.no_git, force_publish=args.all_ids, is_multilingual=args.is_multilingual,
-                                                           modern_text_encoding=args.modern_text_encoding)
+                                                           use_xslt_processing=args.use_xslt_processing)
             else:
                 logger.error(f"{args.project} is not in the API configuration or lacks 'comments_database' setting, aborting...")
                 sys.exit(1)

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -503,12 +503,12 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
                 xslt_execs: Dict[str, Optional[PyXsltExecutable]] = {}
 
                 for type_key, xsl_path in [
-                    ("est", EST_XSL_PATH_IN_FILE_ROOT), 
+                    ("est", EST_XSL_PATH_IN_FILE_ROOT),
                     ("com", COM_XSL_PATH_IN_FILE_ROOT),
                     ("ms", MS_XSL_PATH_IN_FILE_ROOT)
                 ]:
                     xsl_full_path = os.path.join(config[project]["file_root"], xsl_path)
-                    
+
                     if os.path.exists(xsl_full_path):
                         xslt_execs[type_key] = xslt_proc.compile_stylesheet(stylesheet_file=xsl_full_path, encoding="utf-8")
                     else:
@@ -579,6 +579,7 @@ def check_publication_mtimes_and_publish_files(project: str, publication_ids: Un
                             md5sums.append(calculate_checksum(com_target_file_path))
                         else:
                             md5sums.append("SKIP")
+
                         if modern_text_encoding:
                             generate_modern_est_and_com_files(row,
                                                               project,

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -24,9 +24,9 @@ valid_projects = [project for project in config if isinstance(config[project], d
 
 comment_db_engines = {project: create_engine(config[project]["comments_database"], pool_pre_ping=True) for project in valid_projects}
 
-EST_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/est.xsl"
-COM_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/com.xsl"
-MS_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/ms.xsl"
+EST_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/publish_est.xsl"
+COM_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/publish_com.xsl"
+MS_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/publish_ms.xsl"
 LEGACY_COMMENTS_XSL_PATH_IN_FILE_ROOT = "xslt/comment_html_to_tei.xsl"
 COMMENTS_TEMPLATE_PATH_IN_FILE_ROOT = "templates/comment.xml"
 
@@ -272,6 +272,9 @@ def generate_modern_est_and_com_files(publication_info: Optional[Dict[str, Any]]
                                       com_target_file_path: str,
                                       saxon_proc: PySaxonProcessor,
                                       xslt_execs: Dict[str, Optional[PyXsltExecutable]]):
+    """
+    Generates published est and com files using XSLT processing.
+    """
     try:
         est_document = SaxonXMLDocument(saxon_proc, xml_filepath=est_source_file_path)
         est_params = {}
@@ -382,6 +385,9 @@ def generate_modern_ms_file(publication_info: Optional[Dict[str, Any]],
                             target_file_path: str,
                             saxon_proc: PySaxonProcessor,
                             xslt_execs: Dict[str, Optional[PyXsltExecutable]]):
+    """
+    Generates a published ms file using XSLT processing.
+    """
     try:
         ms_document = SaxonXMLDocument(saxon_proc, xml_filepath=source_file_path)
         ms_params = {}

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -24,9 +24,9 @@ valid_projects = [project for project in config if isinstance(config[project], d
 
 comment_db_engines = {project: create_engine(config[project]["comments_database"], pool_pre_ping=True) for project in valid_projects}
 
-EST_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/publish-est.xsl"
-COM_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/publish-com.xsl"
-MS_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/publish-ms.xsl"
+EST_WEB_XML_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/generate-web-xml-est.xsl"
+COM_WEB_XML_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/generate-web-xml-com.xsl"
+MS_WEB_XML_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/generate-web-xml-ms.xsl"
 LEGACY_COMMENTS_XSL_PATH_IN_FILE_ROOT = "xslt/comment_html_to_tei.xsl"
 COMMENTS_TEMPLATE_PATH_IN_FILE_ROOT = "templates/comment.xml"
 
@@ -226,9 +226,9 @@ def compile_xslt_stylesheets(
     xslt_execs: Dict[str, Optional[PyXsltExecutable]] = {}
 
     for type_key, xsl_path in [
-        ("est", EST_XSL_PATH_IN_FILE_ROOT),
-        ("com", COM_XSL_PATH_IN_FILE_ROOT),
-        ("ms", MS_XSL_PATH_IN_FILE_ROOT)
+        ("est", EST_WEB_XML_XSL_PATH_IN_FILE_ROOT),
+        ("com", COM_WEB_XML_XSL_PATH_IN_FILE_ROOT),
+        ("ms", MS_WEB_XML_XSL_PATH_IN_FILE_ROOT)
     ]:
         xsl_full_path = os.path.join(config[project]["file_root"], xsl_path)
 
@@ -315,7 +315,7 @@ def generate_est_and_com_files_with_xslt(publication_info: Optional[Dict[str, An
     Generates published est and com files using XSLT processing.
     """
     if xslt_execs["est"] is None:
-        logger.warning(f"XSLT executable for 'est' is missing. '{EST_XSL_PATH_IN_FILE_ROOT}' is invalid or does not exist in project root.")
+        logger.warning(f"XSLT executable for 'est' is missing. '{EST_WEB_XML_XSL_PATH_IN_FILE_ROOT}' is invalid or does not exist in project root.")
         # Don't raise an exception here in case the XSLT for est is
         # intentionally missing, for example if the project doesn't
         # have est files. This still allows com files to be processed.
@@ -352,7 +352,7 @@ def generate_est_and_com_files_with_xslt(publication_info: Optional[Dict[str, An
         return
 
     if xslt_execs["com"] is None:
-        logger.warning(f"XSLT executable for 'com' is missing. '{COM_XSL_PATH_IN_FILE_ROOT}' is invalid or does not exist in project root. Comment file not generated.")
+        logger.warning(f"XSLT executable for 'com' is missing. '{COM_WEB_XML_XSL_PATH_IN_FILE_ROOT}' is invalid or does not exist in project root. Comment file not generated.")
         # Don't raise an exception here so the est file can still be committed.
         return
 
@@ -444,7 +444,7 @@ def generate_ms_file_with_xslt(publication_info: Optional[Dict[str, Any]],
     """
     try:
         if xslt_execs["ms"] is None:
-            logger.error(f"XSLT executable for 'ms' is missing. '{MS_XSL_PATH_IN_FILE_ROOT}' is invalid or does not exist in project root.")
+            logger.error(f"XSLT executable for 'ms' is missing. '{MS_WEB_XML_XSL_PATH_IN_FILE_ROOT}' is invalid or does not exist in project root.")
             raise ValueError("XSLT executable for 'ms' is missing.")
 
         ms_document = SaxonXMLDocument(saxon_proc, xml_filepath=source_file_path)

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -24,9 +24,9 @@ valid_projects = [project for project in config if isinstance(config[project], d
 
 comment_db_engines = {project: create_engine(config[project]["comments_database"], pool_pre_ping=True) for project in valid_projects}
 
-EST_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/publish_est.xsl"
-COM_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/publish_com.xsl"
-MS_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/publish_ms.xsl"
+EST_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/publish-est.xsl"
+COM_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/publish-com.xsl"
+MS_XSL_PATH_IN_FILE_ROOT = "xslt/publisher/publish-ms.xsl"
 LEGACY_COMMENTS_XSL_PATH_IN_FILE_ROOT = "xslt/comment_html_to_tei.xsl"
 COMMENTS_TEMPLATE_PATH_IN_FILE_ROOT = "templates/comment.xml"
 

--- a/sls_api/scripts/saxon_xml_document.py
+++ b/sls_api/scripts/saxon_xml_document.py
@@ -6,339 +6,339 @@ from saxonche import PySaxonApiError, PySaxonProcessor, PyXdmNode, PyXdmValue, P
 
 
 class SaxonXMLDocument:
-  """
-  A class for processing XML documents using SaxonC's Python extension.
-
-  This class provides methods to load, parse, and manipulate XML documents,
-  with support for configurable namespaces and XPath evaluations.
-
-  Attributes:
-  - xml_doc_tree (PyXdmNode): Parsed XML tree representation.
-  - xml_doc_str (str): String representation of the loaded XML document.
-  - saxon_proc (PySaxonProcessor): An instance of PySaxonProcessor for
-    SaxonC operations.
-  - config (dict): Configuration dictionary containing namespace mappings.
-  - namespaces (list): List of namespaces to declare for XPath evaluation.
-
-  Methods:
-  - load_xml_file(filepath): Loads an XML document from a file and parses it.
-  - generate_web_xml_file(xslt_exec, output_filepath): Generates a
-    transformed XML file using XSLT.
-  - get_all_comment_ids(): Extracts all comment IDs matching a specific
-    XPath query.
-  - _parse_from_string(xml_str): Parses an XML document from a string.
-  - _evaluate_xpath(xpath_str): Evaluates an XPath expression using the
-    configured namespaces.
-  - _save_to_file(output_filepath): Saves the current XML document to a file.
-  - _move_end_anchors(xml_str): Adjusts the position of end anchors in the
-    XML.
-
-  Parameters (during initialization):
-  - saxon_proc (PySaxonProcessor): Instance of PySaxonProcessor for handling
-    XML parsing and XPath evaluation.
-  - xml_filepath (optional, str): Path to an XML file to load upon
-    initialization.
-  - config (optional, dict): Configuration dictionary containing namespace
-    mappings. Defaults to TEI and XML namespaces.
-  """
-
-
-  def __init__(
-      self, 
-      saxon_proc: PySaxonProcessor, 
-      xml_filepath: str = "", 
-      config: Optional[Dict[str, Any]] = None
-  ):
     """
-    Initializes a SaxonXMLDocument instance.
+    A class for processing XML documents using SaxonC's Python extension.
 
-    Parameters:
+    This class provides methods to load, parse, and manipulate XML documents,
+    with support for configurable namespaces and XPath evaluations.
+
+    Attributes:
+    - xml_doc_tree (PyXdmNode): Parsed XML tree representation.
+    - xml_doc_str (str): String representation of the loaded XML document.
     - saxon_proc (PySaxonProcessor): An instance of PySaxonProcessor for
-      handling XML parsing and XPath evaluation.
-    - xml_filepath (str, optional): The file path of an XML document to
-      load upon initialization. If provided, the XML document will be
-      immediately loaded.
-    - config (dict, optional): A configuration dictionary containing
-      namespace mappings. Defaults to:
-      {
-        "namespaces": [
-          {"prefix": "xml", "uri": "http://www.w3.org/XML/1998/namespace"},
-          {"prefix": "tei", "uri": "http://www.tei-c.org/ns/1.0"}
-        ]
-      }
+        SaxonC operations.
+    - config (dict): Configuration dictionary containing namespace mappings.
+    - namespaces (list): List of namespaces to declare for XPath evaluation.
 
-    Raises:
-    - FileNotFoundError: If the specified XML file is not found.
-    - ValueError: If the file cannot be loaded due to invalid content.
+    Methods:
+    - load_xml_file(filepath): Loads an XML document from a file and parses it.
+    - generate_web_xml_file(xslt_exec, output_filepath): Generates a
+        transformed XML file using XSLT.
+    - get_all_comment_ids(): Extracts all comment IDs matching a specific
+        XPath query.
+    - _parse_from_string(xml_str): Parses an XML document from a string.
+    - _evaluate_xpath(xpath_str): Evaluates an XPath expression using the
+        configured namespaces.
+    - _save_to_file(output_filepath): Saves the current XML document to a file.
+    - _move_end_anchors(xml_str): Adjusts the position of end anchors in the
+        XML.
+
+    Parameters (during initialization):
+    - saxon_proc (PySaxonProcessor): Instance of PySaxonProcessor for handling
+        XML parsing and XPath evaluation.
+    - xml_filepath (optional, str): Path to an XML file to load upon
+        initialization.
+    - config (optional, dict): Configuration dictionary containing namespace
+        mappings. Defaults to TEI and XML namespaces.
     """
-    self.xml_doc_tree: PyXdmNode = None
-    self.xml_doc_str: str = ""
-    self.saxon_proc: PySaxonProcessor = saxon_proc
-
-    self.config = config or {
-      "namespaces": [
-        {"prefix": "xml", "uri": "http://www.w3.org/XML/1998/namespace"},
-        {"prefix": "tei", "uri": "http://www.tei-c.org/ns/1.0"}
-      ]
-    }
-    self.namespaces = self.config["namespaces"]
-
-    if xml_filepath:
-      try:
-        self.load_xml_file(filepath=xml_filepath)
-      except FileNotFoundError:
-        raise FileNotFoundError(f"The file '{xml_filepath}' does not exist.")
-      except Exception as e:
-        raise ValueError(f"Failed to load XML file '{xml_filepath}': {e}")
 
 
-  def load_xml_file(self, filepath: str) -> bool:
-    """
-    Loads an XML document from a file.
+    def __init__(
+            self, 
+            saxon_proc: PySaxonProcessor, 
+            xml_filepath: str = "", 
+            config: Optional[Dict[str, Any]] = None
+    ):
+        """
+        Initializes a SaxonXMLDocument instance.
 
-    Parameters:
-    - filepath (str): The file path of the XML document to load.
+        Parameters:
+        - saxon_proc (PySaxonProcessor): An instance of PySaxonProcessor for
+            handling XML parsing and XPath evaluation.
+        - xml_filepath (str, optional): The file path of an XML document to
+            load upon initialization. If provided, the XML document will be
+            immediately loaded.
+        - config (dict, optional): A configuration dictionary containing
+            namespace mappings. Defaults to:
+            {
+                "namespaces": [
+                    {"prefix": "xml", "uri": "http://www.w3.org/XML/1998/namespace"},
+                    {"prefix": "tei", "uri": "http://www.tei-c.org/ns/1.0"}
+                ]
+            }
 
-    Returns:
-    - bool: True if the file is loaded successfully.
+        Raises:
+        - FileNotFoundError: If the specified XML file is not found.
+        - ValueError: If the file cannot be loaded due to invalid content.
+        """
+        self.xml_doc_tree: PyXdmNode = None
+        self.xml_doc_str: str = ""
+        self.saxon_proc: PySaxonProcessor = saxon_proc
 
-    Raises:
-    - FileNotFoundError: If the file does not exist.
-    - ValueError: If the file cannot be read or parsed.
-    """
-    try:
-      with io.open(filepath, mode="r", encoding="utf-8-sig") as xml_file:
-        self.xml_doc_str = xml_file.read()
-        self.xml_doc_tree = self._parse_from_string(xml_str=self.xml_doc_str)
-        return True
-    except FileNotFoundError:
-      raise FileNotFoundError(f"The file '{filepath}' was not found.")
-    except (EnvironmentError, PySaxonApiError) as e:
-      raise ValueError(f"Error reading or parsing the file '{filepath}': {e}")
+        self.config = config or {
+            "namespaces": [
+                {"prefix": "xml", "uri": "http://www.w3.org/XML/1998/namespace"},
+                {"prefix": "tei", "uri": "http://www.tei-c.org/ns/1.0"}
+            ]
+        }
+        self.namespaces = self.config["namespaces"]
 
-
-  def generate_web_xml_file(
-      self,
-      xslt_exec: PyXsltExecutable,
-      output_filepath: str,
-      parameters: Optional[Dict] = None
-  ):
-    """
-    Generates a transformed XML file using an XSLT processor.
-
-    Parameters:
-    - xslt_exec (PyXsltExecutable): The XSLT execution object.
-    - output_filepath (str): The file path where the transformed XML will
-      be saved.
-    - parameters (dict, optional): A dictionary with parameters for the XSLT
-      processor. Defaults to None.
-    """
-    # Initialize parameters as an empty dictionary if None is passed
-    parameters = parameters or {}
-
-    # Clear any parameters previously set on the XSLT processor
-    xslt_exec.clear_parameters()
-
-    if parameters:
-      self._set_xslt_params_from_dict(xslt_exec, parameters)
-
-    self.xml_doc_str = xslt_exec.transform_to_string(xdm_node=self.xml_doc_tree)
-    self._save_to_file(output_filepath=output_filepath)
+        if xml_filepath:
+            try:
+                self.load_xml_file(filepath=xml_filepath)
+            except FileNotFoundError:
+                raise FileNotFoundError(f"The file '{xml_filepath}' does not exist.")
+            except Exception as e:
+                raise ValueError(f"Failed to load XML file '{xml_filepath}': {e}")
 
 
-  def _save_to_file(self, output_filepath: str):
-    """
-    Saves the XML document to the specified output file.
+    def load_xml_file(self, filepath: str) -> bool:
+        """
+        Loads an XML document from a file.
 
-    Parameters:
-    - output_filepath (str): The file path where the XML document will be
-      saved.
-    """
-    with open(output_filepath, "w", encoding="utf-8") as file:
-      xml_str = self._remove_blank_lines(self.xml_doc_str)
-      xml_str = self._format_xml_with_line_endings(xml_str)
-      file.write(xml_str)
+        Parameters:
+        - filepath (str): The file path of the XML document to load.
+
+        Returns:
+        - bool: True if the file is loaded successfully.
+
+        Raises:
+        - FileNotFoundError: If the file does not exist.
+        - ValueError: If the file cannot be read or parsed.
+        """
+        try:
+            with io.open(filepath, mode="r", encoding="utf-8-sig") as xml_file:
+                self.xml_doc_str = xml_file.read()
+                self.xml_doc_tree = self._parse_from_string(xml_str=self.xml_doc_str)
+                return True
+        except FileNotFoundError:
+            raise FileNotFoundError(f"The file '{filepath}' was not found.")
+        except (EnvironmentError, PySaxonApiError) as e:
+            raise ValueError(f"Error reading or parsing the file '{filepath}': {e}")
 
 
-  def get_all_comment_ids(self) -> List[int]:
-    """
-    Extracts all comment IDs from the XML document as integers.
+    def generate_web_xml_file(
+            self,
+            xslt_exec: PyXsltExecutable,
+            output_filepath: str,
+            parameters: Optional[Dict] = None
+    ):
+        """
+        Generates a transformed XML file using an XSLT processor.
 
-    The method evaluates an XPath query to find all `@xml:id` attributes
-    of <tei:anchor> elements whose IDs start with "start". The "start"
-    prefix is removed, and the remaining part of the ID is converted to
-    an integer.
+        Parameters:
+        - xslt_exec (PyXsltExecutable): The XSLT execution object.
+        - output_filepath (str): The file path where the transformed XML will
+            be saved.
+        - parameters (dict, optional): A dictionary with parameters for the XSLT
+            processor. Defaults to None.
+        """
+        # Initialize parameters as an empty dictionary if None is passed
+        parameters = parameters or {}
 
-    Returns:
-    - list of int: A list of extracted comment IDs as integers.
+        # Clear any parameters previously set on the XSLT processor
+        xslt_exec.clear_parameters()
 
-    Raises:
-    - ValueError: If any extracted ID (after removing the "start" prefix) is
-      not a valid integer.
-    """
-    result = self._evaluate_xpath('//tei:anchor[starts-with(@xml:id,"start")]/@xml:id')
+        if parameters:
+            self._set_xslt_params_from_dict(xslt_exec, parameters)
 
-    ids = []
-    for i in range(result.size):
-      comment_id = result[i].get_string_value(encoding="utf-8")
-      try:
-        ids.append(int(comment_id[5:]))  # Convert to integer after slicing
-      except ValueError:
-        raise ValueError(f"Invalid ID: '{comment_id}' is not convertible to an integer.")
+        self.xml_doc_str = xslt_exec.transform_to_string(xdm_node=self.xml_doc_tree)
+        self._save_to_file(output_filepath=output_filepath)
 
-    return ids
-  
 
-  def get_all_comment_positions(self, comment_ids: List[int]) -> Dict[str, Any]:
-    xml_doc = self._parse_from_string(self.xml_doc_str)
-    id_prefixes = ["start", "end"]
-    comment_positions = {}
+    def _save_to_file(self, output_filepath: str):
+        """
+        Saves the XML document to the specified output file.
 
-    for comment_id in comment_ids:
-      for prefix in id_prefixes:
-        position = "none"
-        xml_id = prefix + str(comment_id)
-        xp_result = self._evaluate_xpath('tei:anchor[@xml:id = "' + xml_id + '"]/ancestor::*[self::tei:p or self::tei:lg or self::tei:l][@n][1]/@n', xml_doc)
+        Parameters:
+        - output_filepath (str): The file path where the XML document will be
+            saved.
+        """
+        with open(output_filepath, "w", encoding="utf-8") as file:
+            xml_str = self._remove_blank_lines(self.xml_doc_str)
+            xml_str = self._format_xml_with_line_endings(xml_str)
+            file.write(xml_str)
 
-        if xp_result.size > 0:
-          position = xp_result[0].get_string_value(encoding="utf-8")
+
+    def get_all_comment_ids(self) -> List[int]:
+        """
+        Extracts all comment IDs from the XML document as integers.
+
+        The method evaluates an XPath query to find all `@xml:id` attributes
+        of <tei:anchor> elements whose IDs start with "start". The "start"
+        prefix is removed, and the remaining part of the ID is converted to
+        an integer.
+
+        Returns:
+        - list of int: A list of extracted comment IDs as integers.
+
+        Raises:
+        - ValueError: If any extracted ID (after removing the "start" prefix) is
+            not a valid integer.
+        """
+        result = self._evaluate_xpath('//tei:anchor[starts-with(@xml:id,"start")]/@xml:id')
+
+        ids = []
+        for i in range(result.size):
+            comment_id = result[i].get_string_value(encoding="utf-8")
+            try:
+                ids.append(int(comment_id[5:]))  # Convert to integer after slicing
+            except ValueError:
+                raise ValueError(f"Invalid ID: '{comment_id}' is not convertible to an integer.")
+
+        return ids
+    
+
+    def get_all_comment_positions(self, comment_ids: List[int]) -> Dict[str, Any]:
+        xml_doc = self._parse_from_string(self.xml_doc_str)
+        id_prefixes = ["start", "end"]
+        comment_positions = {}
+
+        for comment_id in comment_ids:
+            for prefix in id_prefixes:
+                position = "none"
+                xml_id = prefix + str(comment_id)
+                xp_result = self._evaluate_xpath('tei:anchor[@xml:id = "' + xml_id + '"]/ancestor::*[self::tei:p or self::tei:lg or self::tei:l][@n][1]/@n', xml_doc)
+
+                if xp_result.size > 0:
+                    position = xp_result[0].get_string_value(encoding="utf-8")
+                else:
+                    # The comment anchor is in an unnumbered ancestor, check if in a
+                    # <head>, <note> or <date> element
+                    xp_result = self._evaluate_xpath('tei:anchor[@xml:id = "' + xml_id + '"]/ancestor::*[self::tei:head or self::tei:note or self::tei:date][1]/name()', xml_doc)
+
+                    if xp_result.size > 0:
+                        position = xp_result[0].get_string_value(encoding="utf-8")
+
+                        if position == "head":
+                            xp_result = self._evaluate_xpath('tei:anchor[@xml:id = "' + xml_id + '"]/ancestor::*[self::tei:text or self::tei:div][@type][1]/@type', xml_doc)
+
+                            if xp_result.size > 0:
+                                head_type = xp_result[0].get_string_value(encoding="utf-8")
+
+                                if head_type == "poem":
+                                    position = "title"
+
+                comment_positions[xml_id] = position
+
+        return comment_positions
+
+
+    def _parse_from_string(self, xml_str: str) -> PyXdmNode:
+        """
+        Parses the XML document provided as a string.
+
+        Parameters:
+        - xml_str (str): String representation of an XML document.
+
+        Returns:
+        - The XDM node representation of the XML document (PyXdmNode).
+        """
+        return self.saxon_proc.parse_xml(xml_text=xml_str, encoding="utf-8")
+
+
+    def _evaluate_xpath(self, xpath_str: str, node: Optional[PyXdmNode] = None) -> PyXdmValue:
+        """
+        Evaluates an XPath expression using the configured namespaces.
+
+        Parameters:
+        - xpath_str (str): The XPath expression to evaluate.
+        - node (PyXdmNode, optional): The context node for the XPath query.
+
+        Returns:
+        - Result of the XPath evaluation (PyXdmValue).
+        """
+        xp_proc = self.saxon_proc.new_xpath_processor()
+
+        for ns in self.namespaces:
+            xp_proc.declare_namespace(prefix=ns["prefix"], uri=ns["uri"])
+
+        node = node or self._parse_from_string(self.xml_doc_str)
+        xp_proc.set_context(xdm_item=node)
+
+        return xp_proc.evaluate(xpath_str, encoding="utf-8")
+
+
+    def _remove_blank_lines(self, input_string: str) -> str:
+        """
+        Removes blank lines (lines with only whitespace or no content) from
+        a given string.
+
+        Parameters:
+        - input_string (str): The input string containing lines of text.
+
+        Returns:
+        - A string with blank lines removed.
+        """
+        return "".join(line for line in input_string.splitlines(keepends=True) if line.strip())
+
+
+    def _format_xml_with_line_endings(self, xml_string: str) -> str:
+        """
+        Formats an XML string to add line endings after the XML declaration
+        and processing instructions.
+
+        Parameters:
+        - xml_string (str): The XML string to format.
+
+        Returns:
+        - The formatted XML string with line endings added.
+        """
+        # Regular expression to match the XML declaration and processing instructions
+        pattern = r"(<\?xml[^>]+\?>)"
+
+        # Replace each match with itself followed by a newline
+        formatted_xml = re.sub(pattern, r"\1\n", xml_string)
+
+        return formatted_xml
+
+
+    def _set_xslt_params_from_dict(
+            self,
+            xslt_exec: PyXsltExecutable,
+            parameters: dict
+    ):
+        """
+        Sets parameters for an XSLT processor from a dictionary.
+
+        Parameters:
+        - xslt_exec (PyXsltExecutable): The XSLT execution object where the parameters
+            will be set.
+        - parameters (dict): A dictionary containing parameter names and their
+            corresponding values. The values will be converted to the appropriate XDM
+            type before being set on the XSLT processor.
+        """
+        for param_name, param_value in parameters.items():
+            xslt_exec.set_parameter(name=param_name, value=self._convert_primitive_type_to_xdm(param_value))
+
+
+    def _convert_primitive_type_to_xdm(self, value: any) -> PyXdmValue:
+        """
+        Converts a primitive Python value to an XDM-compatible value.
+
+        Parameters:
+        - value (any): A primitive Python value (int, str, bool, float) to be 
+            converted to an XDM value for use with the Saxon processor.
+
+        Returns:
+        - PyXdmValue: The XDM representation of the input value. If the input value
+            does not match a recognized type, an empty XDM sequence is returned.
+
+        Behavior:
+        - Converts Python types to their XDM equivalents:
+                - `int` -> XDM Integer
+                - `str` -> XDM String (UTF-8 encoded by default)
+                - `bool` -> XDM Boolean
+                - `float` -> XDM Float
+        - For unsupported types, returns an empty XDM sequence.
+        """
+        if isinstance(value, int):
+            return self.saxon_proc.make_integer_value(value)
+        elif isinstance(value, str):
+            return self.saxon_proc.make_string_value(value, encoding="utf-8")
+        elif isinstance(value, bool):
+            return self.saxon_proc.make_boolean_value(value)
+        elif isinstance(value, float):
+            return self.saxon_proc.make_float_value(value)
         else:
-          # The comment anchor is in an unnumbered ancestor, check if in a
-          # <head>, <note> or <date> element
-          xp_result = self._evaluate_xpath('tei:anchor[@xml:id = "' + xml_id + '"]/ancestor::*[self::tei:head or self::tei:note or self::tei:date][1]/name()', xml_doc)
-
-          if xp_result.size > 0:
-            position = xp_result[0].get_string_value(encoding="utf-8")
-
-            if position == "head":
-              xp_result = self._evaluate_xpath('tei:anchor[@xml:id = "' + xml_id + '"]/ancestor::*[self::tei:text or self::tei:div][@type][1]/@type', xml_doc)
-
-              if xp_result.size > 0:
-                head_type = xp_result[0].get_string_value(encoding="utf-8")
-
-                if head_type == "poem":
-                  position = "title"
-
-        comment_positions[xml_id] = position
-
-    return comment_positions
-
-
-  def _parse_from_string(self, xml_str: str) -> PyXdmNode:
-    """
-    Parses the XML document provided as a string.
-
-    Parameters:
-    - xml_str (str): String representation of an XML document.
-
-    Returns:
-    - The XDM node representation of the XML document (PyXdmNode).
-    """
-    return self.saxon_proc.parse_xml(xml_text=xml_str, encoding="utf-8")
-
-
-  def _evaluate_xpath(self, xpath_str: str, node: Optional[PyXdmNode] = None) -> PyXdmValue:
-    """
-    Evaluates an XPath expression using the configured namespaces.
-
-    Parameters:
-    - xpath_str (str): The XPath expression to evaluate.
-    - node (PyXdmNode, optional): The context node for the XPath query.
-
-    Returns:
-    - Result of the XPath evaluation (PyXdmValue).
-    """
-    xp_proc = self.saxon_proc.new_xpath_processor()
-
-    for ns in self.namespaces:
-      xp_proc.declare_namespace(prefix=ns["prefix"], uri=ns["uri"])
-
-    node = node or self._parse_from_string(self.xml_doc_str)
-    xp_proc.set_context(xdm_item=node)
-
-    return xp_proc.evaluate(xpath_str, encoding="utf-8")
-
-
-  def _remove_blank_lines(self, input_string: str) -> str:
-    """
-    Removes blank lines (lines with only whitespace or no content) from
-    a given string.
-
-    Parameters:
-    - input_string (str): The input string containing lines of text.
-
-    Returns:
-    - A string with blank lines removed.
-    """
-    return "".join(line for line in input_string.splitlines(keepends=True) if line.strip())
-
-
-  def _format_xml_with_line_endings(self, xml_string: str) -> str:
-    """
-    Formats an XML string to add line endings after the XML declaration
-    and processing instructions.
-
-    Parameters:
-    - xml_string (str): The XML string to format.
-
-    Returns:
-    - The formatted XML string with line endings added.
-    """
-    # Regular expression to match the XML declaration and processing instructions
-    pattern = r"(<\?xml[^>]+\?>)"
-
-    # Replace each match with itself followed by a newline
-    formatted_xml = re.sub(pattern, r"\1\n", xml_string)
-
-    return formatted_xml
-
-
-  def _set_xslt_params_from_dict(
-      self,
-      xslt_exec: PyXsltExecutable,
-      parameters: dict
-  ):
-    """
-    Sets parameters for an XSLT processor from a dictionary.
-
-    Parameters:
-    - xslt_exec (PyXsltExecutable): The XSLT execution object where the parameters
-      will be set.
-    - parameters (dict): A dictionary containing parameter names and their
-      corresponding values. The values will be converted to the appropriate XDM
-      type before being set on the XSLT processor.
-    """
-    for param_name, param_value in parameters.items():
-      xslt_exec.set_parameter(name=param_name, value=self._convert_primitive_type_to_xdm(param_value))
-
-
-  def _convert_primitive_type_to_xdm(self, value: any) -> PyXdmValue:
-    """
-    Converts a primitive Python value to an XDM-compatible value.
-
-    Parameters:
-    - value (any): A primitive Python value (int, str, bool, float) to be 
-      converted to an XDM value for use with the Saxon processor.
-
-    Returns:
-    - PyXdmValue: The XDM representation of the input value. If the input value
-      does not match a recognized type, an empty XDM sequence is returned.
-
-    Behavior:
-    - Converts Python types to their XDM equivalents:
-        - `int` -> XDM Integer
-        - `str` -> XDM String (UTF-8 encoded by default)
-        - `bool` -> XDM Boolean
-        - `float` -> XDM Float
-    - For unsupported types, returns an empty XDM sequence.
-    """
-    if isinstance(value, int):
-      return self.saxon_proc.make_integer_value(value)
-    elif isinstance(value, str):
-      return self.saxon_proc.make_string_value(value, encoding="utf-8")
-    elif isinstance(value, bool):
-      return self.saxon_proc.make_boolean_value(value)
-    elif isinstance(value, float):
-      return self.saxon_proc.make_float_value(value)
-    else:
-      return self.saxon_proc.empty_sequence()
+            return self.saxon_proc.empty_sequence()

--- a/sls_api/scripts/saxon_xml_document.py
+++ b/sls_api/scripts/saxon_xml_document.py
@@ -142,18 +142,22 @@ class SaxonXMLDocument:
         self.xml_doc_str = xslt_exec.transform_to_string(xdm_node=self.xml_doc_tree)
         self._save_to_file(output_filepath=output_filepath)
 
-    def _save_to_file(self, output_filepath: str):
+    def add_namespace(self, ns_prefix: str, ns_uri: str):
         """
-        Saves the XML document to the specified output file.
+        Adds the provided namespace to the class config and namespace
+        properties.
 
         Parameters:
-        - output_filepath (str): The file path where the XML document will be
-            saved.
+        - ns_prefix (str): The prefix of the namespace.
+        - ns_uri (str): The URI of the namespace.
         """
-        with open(output_filepath, "w", encoding="utf-8") as file:
-            xml_str = self._remove_blank_lines(self.xml_doc_str)
-            xml_str = self._format_xml_with_line_endings(xml_str)
-            file.write(xml_str)
+        self.config["namespaces"].append(
+            {
+                "prefix": ns_prefix,
+                "uri": ns_uri
+            }
+        )
+        self.namespaces = self.config["namespaces"]
 
     def get_all_comment_ids(self) -> List[int]:
         """
@@ -193,7 +197,7 @@ class SaxonXMLDocument:
 
         for comment_id in comment_ids:
             for prefix in id_prefixes:
-                position = "none"
+                position = "null"
                 xml_id = prefix + str(comment_id)
                 xp_result = self._evaluate_xpath('//tei:anchor[@xml:id = "' + xml_id + '"]/ancestor::*[self::tei:p or self::tei:lg or self::tei:l][@n][1]/@n', xml_doc)
 
@@ -219,6 +223,19 @@ class SaxonXMLDocument:
                 comment_positions[xml_id] = position
 
         return comment_positions
+
+    def _save_to_file(self, output_filepath: str):
+        """
+        Saves the XML document to the specified output file.
+
+        Parameters:
+        - output_filepath (str): The file path where the XML document will be
+            saved.
+        """
+        with open(output_filepath, "w", encoding="utf-8") as file:
+            xml_str = self._remove_blank_lines(self.xml_doc_str)
+            xml_str = self._format_xml_with_line_endings(xml_str)
+            file.write(xml_str)
 
     def _parse_from_string(self, xml_str: str) -> PyXdmNode:
         """

--- a/sls_api/scripts/saxon_xml_document.py
+++ b/sls_api/scripts/saxon_xml_document.py
@@ -16,30 +16,30 @@ class SaxonXMLDocument:
     - xml_doc_tree (PyXdmNode): Parsed XML tree representation.
     - xml_doc_str (str): String representation of the loaded XML document.
     - saxon_proc (PySaxonProcessor): An instance of PySaxonProcessor for
-        SaxonC operations.
+      SaxonC operations.
     - config (dict): Configuration dictionary containing namespace mappings.
     - namespaces (list): List of namespaces to declare for XPath evaluation.
 
     Methods:
     - load_xml_file(filepath): Loads an XML document from a file and parses it.
     - generate_web_xml_file(xslt_exec, output_filepath): Generates a
-        transformed XML file using XSLT.
+      transformed XML file using XSLT.
     - get_all_comment_ids(): Extracts all comment IDs matching a specific
-        XPath query.
+      XPath query.
     - _parse_from_string(xml_str): Parses an XML document from a string.
     - _evaluate_xpath(xpath_str): Evaluates an XPath expression using the
-        configured namespaces.
+      configured namespaces.
     - _save_to_file(output_filepath): Saves the current XML document to a file.
     - _move_end_anchors(xml_str): Adjusts the position of end anchors in the
-        XML.
+      XML.
 
     Parameters (during initialization):
     - saxon_proc (PySaxonProcessor): Instance of PySaxonProcessor for handling
-        XML parsing and XPath evaluation.
+      XML parsing and XPath evaluation.
     - xml_filepath (optional, str): Path to an XML file to load upon
-        initialization.
+      initialization.
     - config (optional, dict): Configuration dictionary containing namespace
-        mappings. Defaults to TEI and XML namespaces.
+      mappings. Defaults to TEI and XML namespaces.
     """
 
     def __init__(
@@ -53,12 +53,12 @@ class SaxonXMLDocument:
 
         Parameters:
         - saxon_proc (PySaxonProcessor): An instance of PySaxonProcessor for
-            handling XML parsing and XPath evaluation.
+          handling XML parsing and XPath evaluation.
         - xml_filepath (str, optional): The file path of an XML document to
-            load upon initialization. If provided, the XML document will be
-            immediately loaded.
+          load upon initialization. If provided, the XML document will be
+          immediately loaded.
         - config (dict, optional): A configuration dictionary containing
-            namespace mappings. Defaults to:
+          namespace mappings. Defaults to:
             {
                 "namespaces": [
                     {"prefix": "xml", "uri": "http://www.w3.org/XML/1998/namespace"},
@@ -126,9 +126,9 @@ class SaxonXMLDocument:
         Parameters:
         - xslt_exec (PyXsltExecutable): The XSLT execution object.
         - output_filepath (str): The file path where the transformed XML will
-            be saved.
+          be saved.
         - parameters (dict, optional): A dictionary with parameters for the XSLT
-            executable. Defaults to None.
+          executable. Defaults to None.
         """
         # Initialize parameters as an empty dictionary if None is passed
         parameters = parameters or {}
@@ -173,7 +173,7 @@ class SaxonXMLDocument:
 
         Raises:
         - ValueError: If any extracted ID (after removing the "start" prefix) is
-            not a valid integer.
+          not a valid integer.
         """
         result = self._evaluate_xpath('//tei:anchor[starts-with(@xml:id,"start")]/@xml:id')
 
@@ -230,7 +230,7 @@ class SaxonXMLDocument:
 
         Parameters:
         - output_filepath (str): The file path where the XML document will be
-            saved.
+          saved.
         """
         with open(output_filepath, "w", encoding="utf-8") as file:
             xml_str = self._remove_blank_lines(self.xml_doc_str)
@@ -312,10 +312,10 @@ class SaxonXMLDocument:
 
         Parameters:
         - xslt_exec (PyXsltExecutable): The XSLT execution object where the parameters
-            will be set.
+          will be set.
         - parameters (dict): A dictionary containing parameter names and their
-            corresponding values. The values will be converted to the appropriate XDM
-            type before being set on the XSLT processor.
+          corresponding values. The values will be converted to the appropriate XDM
+          type before being set on the XSLT processor.
         """
         for param_name, param_value in parameters.items():
             xslt_exec.set_parameter(name=param_name, value=self._convert_primitive_type_to_xdm(param_value))
@@ -326,11 +326,11 @@ class SaxonXMLDocument:
 
         Parameters:
         - value (any): A primitive Python value (int, str, bool, float) to be
-            converted to an XDM value for use with the Saxon processor.
+          converted to an XDM value for use with the Saxon processor.
 
         Returns:
         - PyXdmValue: The XDM representation of the input value. If the input value
-            does not match a recognized type, an empty XDM sequence is returned.
+          does not match a recognized type, an empty XDM sequence is returned.
 
         Behavior:
         - Converts Python types to their XDM equivalents:

--- a/sls_api/scripts/saxon_xml_document.py
+++ b/sls_api/scripts/saxon_xml_document.py
@@ -42,11 +42,10 @@ class SaxonXMLDocument:
         mappings. Defaults to TEI and XML namespaces.
     """
 
-
     def __init__(
-            self, 
-            saxon_proc: PySaxonProcessor, 
-            xml_filepath: str = "", 
+            self,
+            saxon_proc: PySaxonProcessor,
+            xml_filepath: str = "",
             config: Optional[Dict[str, Any]] = None
     ):
         """
@@ -91,7 +90,6 @@ class SaxonXMLDocument:
             except Exception as e:
                 raise ValueError(f"Failed to load XML file '{xml_filepath}': {e}")
 
-
     def load_xml_file(self, filepath: str) -> bool:
         """
         Loads an XML document from a file.
@@ -115,7 +113,6 @@ class SaxonXMLDocument:
             raise FileNotFoundError(f"The file '{filepath}' was not found.")
         except (EnvironmentError, PySaxonApiError) as e:
             raise ValueError(f"Error reading or parsing the file '{filepath}': {e}")
-
 
     def generate_web_xml_file(
             self,
@@ -145,7 +142,6 @@ class SaxonXMLDocument:
         self.xml_doc_str = xslt_exec.transform_to_string(xdm_node=self.xml_doc_tree)
         self._save_to_file(output_filepath=output_filepath)
 
-
     def _save_to_file(self, output_filepath: str):
         """
         Saves the XML document to the specified output file.
@@ -158,7 +154,6 @@ class SaxonXMLDocument:
             xml_str = self._remove_blank_lines(self.xml_doc_str)
             xml_str = self._format_xml_with_line_endings(xml_str)
             file.write(xml_str)
-
 
     def get_all_comment_ids(self) -> List[int]:
         """
@@ -187,7 +182,6 @@ class SaxonXMLDocument:
                 raise ValueError(f"Invalid ID: '{comment_id}' is not convertible to an integer.")
 
         return ids
-    
 
     def get_all_comment_positions(self, comment_ids: List[int]) -> Dict[str, Any]:
         xml_doc = self._parse_from_string(self.xml_doc_str)
@@ -223,7 +217,6 @@ class SaxonXMLDocument:
 
         return comment_positions
 
-
     def _parse_from_string(self, xml_str: str) -> PyXdmNode:
         """
         Parses the XML document provided as a string.
@@ -235,7 +228,6 @@ class SaxonXMLDocument:
         - The XDM node representation of the XML document (PyXdmNode).
         """
         return self.saxon_proc.parse_xml(xml_text=xml_str, encoding="utf-8")
-
 
     def _evaluate_xpath(self, xpath_str: str, node: Optional[PyXdmNode] = None) -> PyXdmValue:
         """
@@ -258,7 +250,6 @@ class SaxonXMLDocument:
 
         return xp_proc.evaluate(xpath_str, encoding="utf-8")
 
-
     def _remove_blank_lines(self, input_string: str) -> str:
         """
         Removes blank lines (lines with only whitespace or no content) from
@@ -271,7 +262,6 @@ class SaxonXMLDocument:
         - A string with blank lines removed.
         """
         return "".join(line for line in input_string.splitlines(keepends=True) if line.strip())
-
 
     def _format_xml_with_line_endings(self, xml_string: str) -> str:
         """
@@ -292,7 +282,6 @@ class SaxonXMLDocument:
 
         return formatted_xml
 
-
     def _set_xslt_params_from_dict(
             self,
             xslt_exec: PyXsltExecutable,
@@ -311,13 +300,12 @@ class SaxonXMLDocument:
         for param_name, param_value in parameters.items():
             xslt_exec.set_parameter(name=param_name, value=self._convert_primitive_type_to_xdm(param_value))
 
-
     def _convert_primitive_type_to_xdm(self, value: any) -> PyXdmValue:
         """
         Converts a primitive Python value to an XDM-compatible value.
 
         Parameters:
-        - value (any): A primitive Python value (int, str, bool, float) to be 
+        - value (any): A primitive Python value (int, str, bool, float) to be
             converted to an XDM value for use with the Saxon processor.
 
         Returns:

--- a/sls_api/scripts/saxon_xml_document.py
+++ b/sls_api/scripts/saxon_xml_document.py
@@ -1,0 +1,344 @@
+import io
+import re
+from typing import Any, Dict, List, Optional
+
+from saxonche import PySaxonApiError, PySaxonProcessor, PyXdmNode, PyXdmValue, PyXsltExecutable
+
+
+class SaxonXMLDocument:
+  """
+  A class for processing XML documents using SaxonC's Python extension.
+
+  This class provides methods to load, parse, and manipulate XML documents,
+  with support for configurable namespaces and XPath evaluations.
+
+  Attributes:
+  - xml_doc_tree (PyXdmNode): Parsed XML tree representation.
+  - xml_doc_str (str): String representation of the loaded XML document.
+  - saxon_proc (PySaxonProcessor): An instance of PySaxonProcessor for
+    SaxonC operations.
+  - config (dict): Configuration dictionary containing namespace mappings.
+  - namespaces (list): List of namespaces to declare for XPath evaluation.
+
+  Methods:
+  - load_xml_file(filepath): Loads an XML document from a file and parses it.
+  - generate_web_xml_file(xslt_exec, output_filepath): Generates a
+    transformed XML file using XSLT.
+  - get_all_comment_ids(): Extracts all comment IDs matching a specific
+    XPath query.
+  - _parse_from_string(xml_str): Parses an XML document from a string.
+  - _evaluate_xpath(xpath_str): Evaluates an XPath expression using the
+    configured namespaces.
+  - _save_to_file(output_filepath): Saves the current XML document to a file.
+  - _move_end_anchors(xml_str): Adjusts the position of end anchors in the
+    XML.
+
+  Parameters (during initialization):
+  - saxon_proc (PySaxonProcessor): Instance of PySaxonProcessor for handling
+    XML parsing and XPath evaluation.
+  - xml_filepath (optional, str): Path to an XML file to load upon
+    initialization.
+  - config (optional, dict): Configuration dictionary containing namespace
+    mappings. Defaults to TEI and XML namespaces.
+  """
+
+
+  def __init__(
+      self, 
+      saxon_proc: PySaxonProcessor, 
+      xml_filepath: str = "", 
+      config: Optional[Dict[str, Any]] = None
+  ):
+    """
+    Initializes a SaxonXMLDocument instance.
+
+    Parameters:
+    - saxon_proc (PySaxonProcessor): An instance of PySaxonProcessor for
+      handling XML parsing and XPath evaluation.
+    - xml_filepath (str, optional): The file path of an XML document to
+      load upon initialization. If provided, the XML document will be
+      immediately loaded.
+    - config (dict, optional): A configuration dictionary containing
+      namespace mappings. Defaults to:
+      {
+        "namespaces": [
+          {"prefix": "xml", "uri": "http://www.w3.org/XML/1998/namespace"},
+          {"prefix": "tei", "uri": "http://www.tei-c.org/ns/1.0"}
+        ]
+      }
+
+    Raises:
+    - FileNotFoundError: If the specified XML file is not found.
+    - ValueError: If the file cannot be loaded due to invalid content.
+    """
+    self.xml_doc_tree: PyXdmNode = None
+    self.xml_doc_str: str = ""
+    self.saxon_proc: PySaxonProcessor = saxon_proc
+
+    self.config = config or {
+      "namespaces": [
+        {"prefix": "xml", "uri": "http://www.w3.org/XML/1998/namespace"},
+        {"prefix": "tei", "uri": "http://www.tei-c.org/ns/1.0"}
+      ]
+    }
+    self.namespaces = self.config["namespaces"]
+
+    if xml_filepath:
+      try:
+        self.load_xml_file(filepath=xml_filepath)
+      except FileNotFoundError:
+        raise FileNotFoundError(f"The file '{xml_filepath}' does not exist.")
+      except Exception as e:
+        raise ValueError(f"Failed to load XML file '{xml_filepath}': {e}")
+
+
+  def load_xml_file(self, filepath: str) -> bool:
+    """
+    Loads an XML document from a file.
+
+    Parameters:
+    - filepath (str): The file path of the XML document to load.
+
+    Returns:
+    - bool: True if the file is loaded successfully.
+
+    Raises:
+    - FileNotFoundError: If the file does not exist.
+    - ValueError: If the file cannot be read or parsed.
+    """
+    try:
+      with io.open(filepath, mode="r", encoding="utf-8-sig") as xml_file:
+        self.xml_doc_str = xml_file.read()
+        self.xml_doc_tree = self._parse_from_string(xml_str=self.xml_doc_str)
+        return True
+    except FileNotFoundError:
+      raise FileNotFoundError(f"The file '{filepath}' was not found.")
+    except (EnvironmentError, PySaxonApiError) as e:
+      raise ValueError(f"Error reading or parsing the file '{filepath}': {e}")
+
+
+  def generate_web_xml_file(
+      self,
+      xslt_exec: PyXsltExecutable,
+      output_filepath: str,
+      parameters: Optional[Dict] = None
+  ):
+    """
+    Generates a transformed XML file using an XSLT processor.
+
+    Parameters:
+    - xslt_exec (PyXsltExecutable): The XSLT execution object.
+    - output_filepath (str): The file path where the transformed XML will
+      be saved.
+    - parameters (dict, optional): A dictionary with parameters for the XSLT
+      processor. Defaults to None.
+    """
+    # Initialize parameters as an empty dictionary if None is passed
+    parameters = parameters or {}
+
+    # Clear any parameters previously set on the XSLT processor
+    xslt_exec.clear_parameters()
+
+    if parameters:
+      self._set_xslt_params_from_dict(xslt_exec, parameters)
+
+    self.xml_doc_str = xslt_exec.transform_to_string(xdm_node=self.xml_doc_tree)
+    self._save_to_file(output_filepath=output_filepath)
+
+
+  def _save_to_file(self, output_filepath: str):
+    """
+    Saves the XML document to the specified output file.
+
+    Parameters:
+    - output_filepath (str): The file path where the XML document will be
+      saved.
+    """
+    with open(output_filepath, "w", encoding="utf-8") as file:
+      xml_str = self._remove_blank_lines(self.xml_doc_str)
+      xml_str = self._format_xml_with_line_endings(xml_str)
+      file.write(xml_str)
+
+
+  def get_all_comment_ids(self) -> List[int]:
+    """
+    Extracts all comment IDs from the XML document as integers.
+
+    The method evaluates an XPath query to find all `@xml:id` attributes
+    of <tei:anchor> elements whose IDs start with "start". The "start"
+    prefix is removed, and the remaining part of the ID is converted to
+    an integer.
+
+    Returns:
+    - list of int: A list of extracted comment IDs as integers.
+
+    Raises:
+    - ValueError: If any extracted ID (after removing the "start" prefix) is
+      not a valid integer.
+    """
+    result = self._evaluate_xpath('//tei:anchor[starts-with(@xml:id,"start")]/@xml:id')
+
+    ids = []
+    for i in range(result.size):
+      comment_id = result[i].get_string_value(encoding="utf-8")
+      try:
+        ids.append(int(comment_id[5:]))  # Convert to integer after slicing
+      except ValueError:
+        raise ValueError(f"Invalid ID: '{comment_id}' is not convertible to an integer.")
+
+    return ids
+  
+
+  def get_all_comment_positions(self, comment_ids: List[int]) -> Dict[str, Any]:
+    xml_doc = self._parse_from_string(self.xml_doc_str)
+    id_prefixes = ["start", "end"]
+    comment_positions = {}
+
+    for comment_id in comment_ids:
+      for prefix in id_prefixes:
+        position = "none"
+        xml_id = prefix + str(comment_id)
+        xp_result = self._evaluate_xpath('tei:anchor[@xml:id = "' + xml_id + '"]/ancestor::*[self::tei:p or self::tei:lg or self::tei:l][@n][1]/@n', xml_doc)
+
+        if xp_result.size > 0:
+          position = xp_result[0].get_string_value(encoding="utf-8")
+        else:
+          # The comment anchor is in an unnumbered ancestor, check if in a
+          # <head>, <note> or <date> element
+          xp_result = self._evaluate_xpath('tei:anchor[@xml:id = "' + xml_id + '"]/ancestor::*[self::tei:head or self::tei:note or self::tei:date][1]/name()', xml_doc)
+
+          if xp_result.size > 0:
+            position = xp_result[0].get_string_value(encoding="utf-8")
+
+            if position == "head":
+              xp_result = self._evaluate_xpath('tei:anchor[@xml:id = "' + xml_id + '"]/ancestor::*[self::tei:text or self::tei:div][@type][1]/@type', xml_doc)
+
+              if xp_result.size > 0:
+                head_type = xp_result[0].get_string_value(encoding="utf-8")
+
+                if head_type == "poem":
+                  position = "title"
+
+        comment_positions[xml_id] = position
+
+    return comment_positions
+
+
+  def _parse_from_string(self, xml_str: str) -> PyXdmNode:
+    """
+    Parses the XML document provided as a string.
+
+    Parameters:
+    - xml_str (str): String representation of an XML document.
+
+    Returns:
+    - The XDM node representation of the XML document (PyXdmNode).
+    """
+    return self.saxon_proc.parse_xml(xml_text=xml_str, encoding="utf-8")
+
+
+  def _evaluate_xpath(self, xpath_str: str, node: Optional[PyXdmNode] = None) -> PyXdmValue:
+    """
+    Evaluates an XPath expression using the configured namespaces.
+
+    Parameters:
+    - xpath_str (str): The XPath expression to evaluate.
+    - node (PyXdmNode, optional): The context node for the XPath query.
+
+    Returns:
+    - Result of the XPath evaluation (PyXdmValue).
+    """
+    xp_proc = self.saxon_proc.new_xpath_processor()
+
+    for ns in self.namespaces:
+      xp_proc.declare_namespace(prefix=ns["prefix"], uri=ns["uri"])
+
+    node = node or self._parse_from_string(self.xml_doc_str)
+    xp_proc.set_context(xdm_item=node)
+
+    return xp_proc.evaluate(xpath_str, encoding="utf-8")
+
+
+  def _remove_blank_lines(self, input_string: str) -> str:
+    """
+    Removes blank lines (lines with only whitespace or no content) from
+    a given string.
+
+    Parameters:
+    - input_string (str): The input string containing lines of text.
+
+    Returns:
+    - A string with blank lines removed.
+    """
+    return "".join(line for line in input_string.splitlines(keepends=True) if line.strip())
+
+
+  def _format_xml_with_line_endings(self, xml_string: str) -> str:
+    """
+    Formats an XML string to add line endings after the XML declaration
+    and processing instructions.
+
+    Parameters:
+    - xml_string (str): The XML string to format.
+
+    Returns:
+    - The formatted XML string with line endings added.
+    """
+    # Regular expression to match the XML declaration and processing instructions
+    pattern = r"(<\?xml[^>]+\?>)"
+
+    # Replace each match with itself followed by a newline
+    formatted_xml = re.sub(pattern, r"\1\n", xml_string)
+
+    return formatted_xml
+
+
+  def _set_xslt_params_from_dict(
+      self,
+      xslt_exec: PyXsltExecutable,
+      parameters: dict
+  ):
+    """
+    Sets parameters for an XSLT processor from a dictionary.
+
+    Parameters:
+    - xslt_exec (PyXsltExecutable): The XSLT execution object where the parameters
+      will be set.
+    - parameters (dict): A dictionary containing parameter names and their
+      corresponding values. The values will be converted to the appropriate XDM
+      type before being set on the XSLT processor.
+    """
+    for param_name, param_value in parameters.items():
+      xslt_exec.set_parameter(name=param_name, value=self._convert_primitive_type_to_xdm(param_value))
+
+
+  def _convert_primitive_type_to_xdm(self, value: any) -> PyXdmValue:
+    """
+    Converts a primitive Python value to an XDM-compatible value.
+
+    Parameters:
+    - value (any): A primitive Python value (int, str, bool, float) to be 
+      converted to an XDM value for use with the Saxon processor.
+
+    Returns:
+    - PyXdmValue: The XDM representation of the input value. If the input value
+      does not match a recognized type, an empty XDM sequence is returned.
+
+    Behavior:
+    - Converts Python types to their XDM equivalents:
+        - `int` -> XDM Integer
+        - `str` -> XDM String (UTF-8 encoded by default)
+        - `bool` -> XDM Boolean
+        - `float` -> XDM Float
+    - For unsupported types, returns an empty XDM sequence.
+    """
+    if isinstance(value, int):
+      return self.saxon_proc.make_integer_value(value)
+    elif isinstance(value, str):
+      return self.saxon_proc.make_string_value(value, encoding="utf-8")
+    elif isinstance(value, bool):
+      return self.saxon_proc.make_boolean_value(value)
+    elif isinstance(value, float):
+      return self.saxon_proc.make_float_value(value)
+    else:
+      return self.saxon_proc.empty_sequence()

--- a/sls_api/scripts/saxon_xml_document.py
+++ b/sls_api/scripts/saxon_xml_document.py
@@ -121,14 +121,14 @@ class SaxonXMLDocument:
             parameters: Optional[Dict] = None
     ):
         """
-        Generates a transformed XML file using an XSLT processor.
+        Generates a transformed XML file using an XSLT executable.
 
         Parameters:
         - xslt_exec (PyXsltExecutable): The XSLT execution object.
         - output_filepath (str): The file path where the transformed XML will
             be saved.
         - parameters (dict, optional): A dictionary with parameters for the XSLT
-            processor. Defaults to None.
+            executable. Defaults to None.
         """
         # Initialize parameters as an empty dictionary if None is passed
         parameters = parameters or {}
@@ -174,6 +174,9 @@ class SaxonXMLDocument:
         result = self._evaluate_xpath('//tei:anchor[starts-with(@xml:id,"start")]/@xml:id')
 
         ids = []
+        if not result:
+            return ids
+
         for i in range(result.size):
             comment_id = result[i].get_string_value(encoding="utf-8")
             try:
@@ -192,22 +195,22 @@ class SaxonXMLDocument:
             for prefix in id_prefixes:
                 position = "none"
                 xml_id = prefix + str(comment_id)
-                xp_result = self._evaluate_xpath('tei:anchor[@xml:id = "' + xml_id + '"]/ancestor::*[self::tei:p or self::tei:lg or self::tei:l][@n][1]/@n', xml_doc)
+                xp_result = self._evaluate_xpath('//tei:anchor[@xml:id = "' + xml_id + '"]/ancestor::*[self::tei:p or self::tei:lg or self::tei:l][@n][1]/@n', xml_doc)
 
-                if xp_result.size > 0:
+                if xp_result and xp_result.size > 0:
                     position = xp_result[0].get_string_value(encoding="utf-8")
                 else:
                     # The comment anchor is in an unnumbered ancestor, check if in a
                     # <head>, <note> or <date> element
-                    xp_result = self._evaluate_xpath('tei:anchor[@xml:id = "' + xml_id + '"]/ancestor::*[self::tei:head or self::tei:note or self::tei:date][1]/name()', xml_doc)
+                    xp_result = self._evaluate_xpath('//tei:anchor[@xml:id = "' + xml_id + '"]/ancestor::*[self::tei:head or self::tei:note or self::tei:date][1]/name()', xml_doc)
 
-                    if xp_result.size > 0:
+                    if xp_result and xp_result.size > 0:
                         position = xp_result[0].get_string_value(encoding="utf-8")
 
                         if position == "head":
-                            xp_result = self._evaluate_xpath('tei:anchor[@xml:id = "' + xml_id + '"]/ancestor::*[self::tei:text or self::tei:div][@type][1]/@type', xml_doc)
+                            xp_result = self._evaluate_xpath('//tei:anchor[@xml:id = "' + xml_id + '"]/ancestor::*[self::tei:text or self::tei:div][@type][1]/@type', xml_doc)
 
-                            if xp_result.size > 0:
+                            if xp_result and xp_result.size > 0:
                                 head_type = xp_result[0].get_string_value(encoding="utf-8")
 
                                 if head_type == "poem":

--- a/sls_api/scripts/saxon_xml_document.py
+++ b/sls_api/scripts/saxon_xml_document.py
@@ -133,7 +133,7 @@ class SaxonXMLDocument:
         # Initialize parameters as an empty dictionary if None is passed
         parameters = parameters or {}
 
-        # Clear any parameters previously set on the XSLT processor
+        # Clear any parameters previously set on the XSLT executable
         xslt_exec.clear_parameters()
 
         if parameters:
@@ -314,10 +314,10 @@ class SaxonXMLDocument:
 
         Behavior:
         - Converts Python types to their XDM equivalents:
-                - `int` -> XDM Integer
-                - `str` -> XDM String (UTF-8 encoded by default)
-                - `bool` -> XDM Boolean
-                - `float` -> XDM Float
+            - `int` -> XDM Integer
+            - `str` -> XDM String (UTF-8 encoded by default)
+            - `bool` -> XDM Boolean
+            - `float` -> XDM Float
         - For unsupported types, returns an empty XDM sequence.
         """
         if isinstance(value, int):

--- a/sls_api/scripts/saxon_xml_document.py
+++ b/sls_api/scripts/saxon_xml_document.py
@@ -22,8 +22,8 @@ class SaxonXMLDocument:
 
     Methods:
     - load_xml_file(filepath): Loads an XML document from a file and parses it.
-    - generate_web_xml_file(xslt_exec, output_filepath): Generates a
-      transformed XML file using XSLT.
+    - transform_and_save(xslt_exec, output_filepath): Generates a
+      transformed document using XSLT.
     - get_all_comment_ids(): Extracts all comment IDs matching a specific
       XPath query.
     - _parse_from_string(xml_str): Parses an XML document from a string.
@@ -114,18 +114,19 @@ class SaxonXMLDocument:
         except (EnvironmentError, PySaxonApiError) as e:
             raise ValueError(f"Error reading or parsing the file '{filepath}': {e}")
 
-    def generate_web_xml_file(
+    def transform_and_save(
             self,
             xslt_exec: PyXsltExecutable,
             output_filepath: str,
             parameters: Optional[Dict] = None
     ):
         """
-        Generates a transformed XML file using an XSLT executable.
+        Transforms the XML document using an XSLT executable and saves the result
+        to the output filepath.
 
         Parameters:
         - xslt_exec (PyXsltExecutable): The XSLT execution object.
-        - output_filepath (str): The file path where the transformed XML will
+        - output_filepath (str): The file path where the transformed document will
           be saved.
         - parameters (dict, optional): A dictionary with parameters for the XSLT
           executable. Defaults to None.


### PR DESCRIPTION
The current publisher script generates web XML files according to a process that was defined for Zacharias Topelius Skrifter (ZTS) over 10 years ago. It requires the source TEI XML files to be encoded using the same principles as ZTS. However, the TEI guidelines have evolved, ZTS was never fully TEI-compliant, and SLS now has new, TEI-compliant guidelines on how texts should be encoded.

This update adds a new processing mode to the publisher script. When this mode is activated, the web XML files are generated from the source files using XSLT which resides in the project files. This brings flexibility, as the XSLT can be modified for each project, if needed, and the source XML files don't necessarily even have to be in TEI XML. XSLT processing of the source files is enabled by utilising the open-source home edition (HE) of SaxonC's Python extension, `saxonche`, which fully supports XSLT 3.0 and XPath 3.1.

The publisher script can be run in the new mode by adding the `--use_xslt_processing` flag. Currently `est`, `com` and `ms` files are handled by the new mode – support for `var` files can be added when and if we have a project that needs it.

The following XSLT files need to exist in the project files root for the processing of each text type to work in the new mode:

- `xslt/publisher/generate-web-xml-est.xsl`
- `xslt/publisher/generate-web-xml-com.xsl`
- `xslt/publisher/generate-web-xml-ms.xsl`

Generic versions of these will be added to and maintained in the repository <https://github.com/slsfi/digital-edition-xml-resources>, from where they can be copied to each project files repository as needed.

**Westermarck** and **Jansson** are the first projects which utilise the updated SLS text encoding guidelines and thus need their web XML files to be generated with the new mode.

Since I don't know how to run the API locally for testing purposes, I haven't been able to test the new mode completely. But I have tested the new functions, the SaxonXMLDocument class and transforming XML using Saxon in a separate test script I have developed.