### PR TITLE
Tools: refactor tags endpoints

### DIFF
--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -656,7 +656,6 @@ def build_select_with_filters(table: Table, filters: dict, columns=None) -> Sele
     return stmt.where(and_(*conditions))
 
 
-
 def create_translation(neutral, connection=None):
     """
     Inserts a new translation record with the provided neutral text and

--- a/sls_api/endpoints/metadata.py
+++ b/sls_api/endpoints/metadata.py
@@ -7,13 +7,10 @@ import json
 import logging
 import os
 import sqlalchemy.sql
-from sqlalchemy import collate, select
 from urllib.parse import unquote
 from werkzeug.security import safe_join
 
-from sls_api.endpoints.generics import db_engine, get_project_config, get_project_id_from_name, \
-    path_hierarchy, select_all_from_table, flatten_json, get_first_valid_item_from_toc, \
-    create_error_response, create_success_response, get_table
+from sls_api.endpoints.generics import db_engine, get_project_config, get_project_id_from_name, path_hierarchy, select_all_from_table, flatten_json, get_first_valid_item_from_toc
 from sls_api.endpoints.tools.files import git_commit_and_push_file
 
 meta = Blueprint('metadata', __name__)
@@ -511,110 +508,20 @@ def get_project_locations(project):
     return jsonify(results)
 
 
+# Get all tags for a project
 @meta.route("/<project>/tags")
 def get_project_tags(project):
-    """
-    List all non-deleted tags/keywords in the specified project.
-    The tags/keywords are alphabetically ordered by name.
-
-    URL Path Parameters:
-
-    - project (str, required): The name of the project to retrieve
-      tags/keywords for (must be a valid project name).
-
-    Returns:
-
-    - A tuple containing a Flask Response object with JSON data and an
-      HTTP status code. The JSON response has the following structure:
-
-        {
-            "success": bool,
-            "message": str,
-            "data": array of objects or null
-        }
-
-    - `success`: A boolean indicating whether the operation was successful.
-    - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, an array of tag/keyword objects; `null`
-       on error.
-
-    Tag/keyword object keys and their data types:
-
-    {
-        "id": number,
-        "date_created": string | null,
-        "date_modified": string | null,
-        "deleted": number,
-        "type": string | null,
-        "name": string | null,
-        "description": string | null,
-        "legacy_id": string | null,
-        "project_id": number,
-        "source": string | null,
-        "name_translation_id": number | null
-    }
-
-    Example Request:
-
-        GET /projectname/tags
-
-    Example Success Response (HTTP 200):
-
-        {
-            "success": true,
-            "message": "Retrieved # keywords.",
-            "data": [
-                {
-                    "id": 123,
-                    "date_created": "2023-05-12T12:34:56",
-                    "date_modified": "2023-06-01T08:22:11",
-                    "deleted": 0,
-                    "type": "filosofiska",
-                    "name": "spelrumsmodellen",
-                    "description": "Description of the keyword.",
-                    "legacy_id": "k3524",
-                    "project_id": 5,
-                    "source": "Encyclopaedia Britannica",
-                    "name_translation_id": 86
-                },
-                ...
-            ]
-        }
-
-    Status Codes:
-
-    - 200 - OK: The tags/keywords are retrieved successfully.
-    - 400 - Bad Request: Invalid project name.
-    - 500 - Internal Server Error: Database query or execution failed.
-    """
     logger.info("Getting /<project>/tags")
-
-    # Verify that project name is valid and get project_id
+    connection = db_engine.connect()
     project_id = get_project_id_from_name(project)
-    if not project_id:
-        return create_error_response("Validation error: 'project' does not exist.")
-
-    tag_table = get_table("tag")
-
-    try:
-        with db_engine.connect() as connection:
-            stmt = (
-                select(*tag_table.c)
-                .where(tag_table.c.project_id == project_id)
-                .where(tag_table.c.deleted < 1)
-                .order_by(
-                    collate(tag_table.c.name, "sv-x-icu")  # Use Swedish collation for sorting å, ä, ö correctly.
-                )
-            )
-            rows = connection.execute(stmt).fetchall()
-            return create_success_response(
-                message=f"Retrieved {len(rows)} keywords.",
-                data=[row._asdict() for row in rows]
-            )
-
-    except Exception:
-        logger.exception("Exception retrieving project tags.")
-        return create_error_response("Unexpected error: failed to retrieve project keywords.", 500)
+    sql = sqlalchemy.sql.text(""" SELECT * FROM tag WHERE project_id = :p_id """)
+    statement = sql.bindparams(p_id=project_id, )
+    results = []
+    for row in connection.execute(statement).fetchall():
+        if row is not None:
+            results.append(row._asdict())
+    connection.close()
+    return jsonify(results)
 
 
 # Get all subjects for a project

--- a/sls_api/endpoints/metadata.py
+++ b/sls_api/endpoints/metadata.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 import sqlalchemy.sql
-from sqlalchemy import select
+from sqlalchemy import collate, select
 from urllib.parse import unquote
 from werkzeug.security import safe_join
 
@@ -515,6 +515,7 @@ def get_project_locations(project):
 def get_project_tags(project):
     """
     List all non-deleted tags/keywords in the specified project.
+    The tags/keywords are alphabetically ordered by name.
 
     URL Path Parameters:
 
@@ -601,6 +602,9 @@ def get_project_tags(project):
                 select(*tag_table.c)
                 .where(tag_table.c.project_id == project_id)
                 .where(tag_table.c.deleted < 1)
+                .order_by(
+                    collate(tag_table.c.name, "sv-x-icu")  # Use Swedish collation for sorting å, ä, ö correctly.
+                )
             )
             rows = connection.execute(stmt).fetchall()
             return create_success_response(

--- a/sls_api/endpoints/tools/events.py
+++ b/sls_api/endpoints/tools/events.py
@@ -2112,7 +2112,7 @@ def add_new_event(project):
         return create_error_response(f"Validation error: '{occurrence_field}' must be a positive integer.")
 
     if occurrence_field == "publication_facsimile_id" and ("publication_facsimile_page" not in request_data or int_or_none(request_data["publication_facsimile_page"]) is None):
-        return create_error_response(f"Validation error: 'publication_facsimile_page' must be provided and be an integer.")
+        return create_error_response("Validation error: 'publication_facsimile_page' must be provided and be an integer.")
 
     # Form values objects
     connection_values = {}
@@ -2163,7 +2163,7 @@ def add_new_event(project):
 
                 # Proceed with creating an event for this connection and occurrence,
                 # as there is no existing event.
-                event_values = { "description": f"project {project_id}" }
+                event_values = {"description": f"project {project_id}"}
 
                 # Insert event query
                 insert_ev_stmt = (

--- a/sls_api/endpoints/tools/events.py
+++ b/sls_api/endpoints/tools/events.py
@@ -1361,12 +1361,14 @@ def list_project_tags(project):
 
     try:
         with db_engine.connect() as connection:
+            collation_name = get_project_collation(project)
+
             stmt = (
                 select(*tag_table.c)
                 .where(tag_table.c.project_id == project_id)
                 .where(tag_table.c.deleted < 1)
                 .order_by(
-                    collate(tag_table.c.name, "sv-x-icu")  # Use Swedish collation for sorting å, ä, ö correctly.
+                    collate(tag_table.c.name, collation_name)
                 )
             )
             rows = connection.execute(stmt).fetchall()

--- a/sls_api/endpoints/tools/events.py
+++ b/sls_api/endpoints/tools/events.py
@@ -1,7 +1,7 @@
 import logging
 from flask import Blueprint, jsonify, request
 from flask_jwt_extended import jwt_required
-from sqlalchemy import and_, asc, cast, desc, select, text, Text
+from sqlalchemy import and_, asc, cast, collate, desc, select, text, Text
 from datetime import datetime
 
 from sls_api.endpoints.generics import db_engine, get_project_id_from_name, get_table, int_or_none, \
@@ -1262,6 +1262,113 @@ def list_translations(project, translation_id):
     except Exception:
         logger.exception("Exception retrieving translations.")
         return create_error_response("Unexpected error: failed to retrieve translations.", 500)
+
+
+@event_tools.route("/<project>/tags/list/")
+@project_permission_required
+def list_project_tags(project):
+    """
+    List all non-deleted tags/keywords in the specified project.
+    The tags/keywords are alphabetically ordered by name.
+
+    URL Path Parameters:
+
+    - project (str, required): The name of the project to retrieve
+      tags/keywords for (must be a valid project name).
+
+    Returns:
+
+    - A tuple containing a Flask Response object with JSON data and an
+      HTTP status code. The JSON response has the following structure:
+
+        {
+            "success": bool,
+            "message": str,
+            "data": array of objects or null
+        }
+
+    - `success`: A boolean indicating whether the operation was successful.
+    - `message`: A string containing a descriptive message about the result.
+    - `data`: On success, an array of tag/keyword objects; `null`
+       on error.
+
+    Tag/keyword object keys and their data types:
+
+    {
+        "id": number,
+        "date_created": string | null,
+        "date_modified": string | null,
+        "deleted": number,
+        "type": string | null,
+        "name": string | null,
+        "description": string | null,
+        "legacy_id": string | null,
+        "project_id": number,
+        "source": string | null,
+        "name_translation_id": number | null
+    }
+
+    Example Request:
+
+        GET /projectname/tags
+
+    Example Success Response (HTTP 200):
+
+        {
+            "success": true,
+            "message": "Retrieved # keywords.",
+            "data": [
+                {
+                    "id": 123,
+                    "date_created": "2023-05-12T12:34:56",
+                    "date_modified": "2023-06-01T08:22:11",
+                    "deleted": 0,
+                    "type": "filosofiska",
+                    "name": "spelrumsmodellen",
+                    "description": "Description of the keyword.",
+                    "legacy_id": "k3524",
+                    "project_id": 5,
+                    "source": "Encyclopaedia Britannica",
+                    "name_translation_id": 86
+                },
+                ...
+            ]
+        }
+
+    Status Codes:
+
+    - 200 - OK: The tags/keywords are retrieved successfully.
+    - 400 - Bad Request: Invalid project name.
+    - 500 - Internal Server Error: Database query or execution failed.
+    """
+    logger.info("Getting /<project>/tags")
+
+    # Verify that project name is valid and get project_id
+    project_id = get_project_id_from_name(project)
+    if not project_id:
+        return create_error_response("Validation error: 'project' does not exist.")
+
+    tag_table = get_table("tag")
+
+    try:
+        with db_engine.connect() as connection:
+            stmt = (
+                select(*tag_table.c)
+                .where(tag_table.c.project_id == project_id)
+                .where(tag_table.c.deleted < 1)
+                .order_by(
+                    collate(tag_table.c.name, "sv-x-icu")  # Use Swedish collation for sorting å, ä, ö correctly.
+                )
+            )
+            rows = connection.execute(stmt).fetchall()
+            return create_success_response(
+                message=f"Retrieved {len(rows)} keywords.",
+                data=[row._asdict() for row in rows]
+            )
+
+    except Exception:
+        logger.exception("Exception retrieving project tags.")
+        return create_error_response("Unexpected error: failed to retrieve project keywords.", 500)
 
 
 @event_tools.route("/<project>/tags/new/", methods=["POST"])

--- a/sls_api/endpoints/tools/events.py
+++ b/sls_api/endpoints/tools/events.py
@@ -2387,10 +2387,10 @@ def delete_event(project, event_id):
                     return create_error_response("Failed to delete connection: invalid event ID or the event occurrence is already deleted.")
 
                 response_data = {
-                    "event_id": upd_ev_row["id"],
+                    "event_id":            upd_ev_row["id"],
                     "event_connection_id": upd_ev_conn_row["id"],
                     "event_occurrence_id": upd_ev_occu_row["id"],
-                    "deleted": upd_ev_row["deleted"]
+                    "deleted":             upd_ev_row["deleted"]
                 }
 
                 return create_success_response(

--- a/sls_api/endpoints/tools/events.py
+++ b/sls_api/endpoints/tools/events.py
@@ -1273,17 +1273,18 @@ def list_translations(project, translation_id):
         return create_error_response("Unexpected error: failed to retrieve translations.", 500)
 
 
-@event_tools.route("/<project>/tags/list/")
+@event_tools.route("/<project>/keywords/list/")
 @project_permission_required
-def list_project_tags(project):
+def list_project_keywords(project):
     """
-    List all non-deleted tags/keywords in the specified project.
-    The tags/keywords are alphabetically ordered by name.
+    List all non-deleted keywords in the specified project.
+    The keywords are alphabetically ordered by name.
+    (Note: keywords are named 'tags' in the database.)
 
     URL Path Parameters:
 
     - project (str, required): The name of the project to retrieve
-      tags/keywords for (must be a valid project name).
+      keywords for (must be a valid project name).
 
     Returns:
 
@@ -1298,10 +1299,10 @@ def list_project_tags(project):
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, an array of tag/keyword objects; `null`
+    - `data`: On success, an array of keyword objects; `null`
        on error.
 
-    Tag/keyword object keys and their data types:
+    Keyword object keys and their data types:
 
     {
         "id": number,
@@ -1319,7 +1320,7 @@ def list_project_tags(project):
 
     Example Request:
 
-        GET /projectname/tags
+        GET /projectname/keywords
 
     Example Success Response (HTTP 200):
 
@@ -1346,12 +1347,10 @@ def list_project_tags(project):
 
     Status Codes:
 
-    - 200 - OK: The tags/keywords are retrieved successfully.
+    - 200 - OK: The keywords are retrieved successfully.
     - 400 - Bad Request: Invalid project name.
     - 500 - Internal Server Error: Database query or execution failed.
     """
-    logger.info("Getting /<project>/tags")
-
     # Verify that project name is valid and get project_id
     project_id = get_project_id_from_name(project)
     if not project_id:
@@ -1378,30 +1377,31 @@ def list_project_tags(project):
             )
 
     except Exception:
-        logger.exception("Exception retrieving project tags.")
+        logger.exception("Exception retrieving project keywords.")
         return create_error_response("Unexpected error: failed to retrieve project keywords.", 500)
 
 
-@event_tools.route("/<project>/tags/new/", methods=["POST"])
+@event_tools.route("/<project>/keywords/new/", methods=["POST"])
 @project_permission_required
-def add_new_tag(project):
+def add_new_keyword(project):
     """
-    Add a new tag/keyword object to the specified project.
+    Add a new keyword object to the specified project.
+    (Note: keywords are named 'tags' in the database.)
 
     URL Path Parameters:
 
     - project (str, required): The name of the project to add the
-      tag/keyword to (must be a valid project name).
+      keyword to (must be a valid project name).
 
     POST Data Parameters in JSON Format:
 
-    - name (str, required): The name of the tag/keyword. Cannot be empty.
-    - type (str, optional): The type or classification of the tag/keyword.
-      Can be used to group or categorise the tags/keywords.
-    - description (str, optional): A description or explanation of the tag/keyword.
-    - source (str, optional): A reference to a source where the tag/keyword
+    - name (str, required): The name of the keyword. Cannot be empty.
+    - type (str, optional): The type or classification of the keyword.
+      Can be used to group or categorise the keywords.
+    - description (str, optional): A description or explanation of the keyword.
+    - source (str, optional): A reference to a source where the keyword
       is defined.
-    - legacy_id (str, optional): Alternate or legacy ID of the tag/keyword.
+    - legacy_id (str, optional): Alternate or legacy ID of the keyword.
 
     Returns:
 
@@ -1416,7 +1416,7 @@ def add_new_tag(project):
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, an object containing the inserted tag/keyword
+    - `data`: On success, an object containing the inserted keyword
       data; `null` on error.
 
     Response object keys and their data types:
@@ -1437,7 +1437,7 @@ def add_new_tag(project):
 
     Example Request:
 
-        POST /projectname/tags/new/
+        POST /projectname/keywords/new/
         {
             "name": "spelrumsmodellen",
             "type": "filosofiska",
@@ -1468,7 +1468,7 @@ def add_new_tag(project):
 
     Status Codes:
 
-    - 201 - OK: The tag/keyword was created successfully.
+    - 201 - OK: The keyword was created successfully.
     - 400 - Bad Request: No data provided or fields are invalid.
     - 500 - Internal Server Error: Database query or execution failed.
     """
@@ -1529,35 +1529,36 @@ def add_new_tag(project):
                 )
 
     except Exception:
-        logger.exception("Exception creating new tag.")
+        logger.exception("Exception creating new keyword.")
         return create_error_response("Unexpected error: failed to create new keyword record.", 500)
 
 
-@event_tools.route("/<project>/tags/<tag_id>/edit/", methods=["POST"])
+@event_tools.route("/<project>/keywords/<keyword_id>/edit/", methods=["POST"])
 @project_permission_required
-def edit_tag(project, tag_id):
+def edit_keyword(project, keyword_id):
     """
-    Edit an existing tag/keyword object in the specified project by
-    updating its fields. If the tag/keyword is deleted, it’s connections
+    Edit an existing keyword object in the specified project by
+    updating its fields. If the keyword is deleted, it’s connections
     to event occurrences are also deleted.
+    (Note: keywords are named 'tags' in the database.)
 
     URL Path Parameters:
 
-    - project (str, required): The name of the project containing the tag/keyword
+    - project (str, required): The name of the project containing the keyword
       to be edited.
-    - tag_id (int, required): The unique identifier of the tag/keyword to be
+    - keyword_id (int, required): The unique identifier of the keyword to be
       updated.
 
     POST Data Parameters in JSON Format (at least one required):
 
-    - name (str): The name of the tag/keyword. Cannot be empty.
-    - type (str): The type or classification of the tag/keyword.
-      Can be used to group or categorise the tags/keywords.
-    - description (str): A description or explanation of the tag/keyword.
-    - source (str): A reference to a source where the tag/keyword
+    - name (str): The name of the keyword. Cannot be empty.
+    - type (str): The type or classification of the keyword.
+      Can be used to group or categorise the keywords.
+    - description (str): A description or explanation of the keyword.
+    - source (str): A reference to a source where the keyword
       is defined.
-    - legacy_id (str): Alternate or legacy ID of the tag/keyword.
-    - deleted (int): Indicates if the tag/keyword is deleted (0 for no,
+    - legacy_id (str): Alternate or legacy ID of the keyword.
+    - deleted (int): Indicates if the keyword is deleted (0 for no,
       1 for yes).
 
     Returns:
@@ -1573,7 +1574,7 @@ def edit_tag(project, tag_id):
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, an object containing the updated tag/keyword data;
+    - `data`: On success, an object containing the updated keyword data;
       `null` on error.
 
     Response object keys and their data types:
@@ -1594,7 +1595,7 @@ def edit_tag(project, tag_id):
 
     Example Request:
 
-        POST /projectname/tags/123/edit/
+        POST /projectname/keywords/123/edit/
         {
             "name": "spelrumsmodellen"
         }
@@ -1623,13 +1624,13 @@ def edit_tag(project, tag_id):
 
         {
             "success": false,
-            "message": "Validation error: 'tag_id' must be a positive integer.",
+            "message": "Validation error: 'keyword_id' must be a positive integer.",
             "data": null
         }
 
     Status Codes:
 
-    - 200 - OK: The tag/keyword was updated successfully.
+    - 200 - OK: The keyword was updated successfully.
     - 400 - Bad Request: No data provided or fields are invalid.
     - 500 - Internal Server Error: Database query or execution failed.
     """
@@ -1638,10 +1639,10 @@ def edit_tag(project, tag_id):
     if not project_id:
         return create_error_response("Validation error: 'project' does not exist.")
 
-    # Convert tag_id to integer and verify
-    tag_id = int_or_none(tag_id)
-    if not tag_id or tag_id < 1:
-        return create_error_response("Validation error: 'tag_id' must be a positive integer.")
+    # Convert keyword_id to integer and verify
+    keyword_id = int_or_none(keyword_id)
+    if not keyword_id or keyword_id < 1:
+        return create_error_response("Validation error: 'keyword_id' must be a positive integer.")
 
     # Verify that request data was provided
     request_data = request.get_json()
@@ -1691,7 +1692,7 @@ def edit_tag(project, tag_id):
                 tag_table = get_table("tag")
                 stmt = (
                     tag_table.update()
-                    .where(tag_table.c.id == tag_id)
+                    .where(tag_table.c.id == keyword_id)
                     .where(tag_table.c.project_id == project_id)
                     .values(**values)
                     .returning(*tag_table.c)  # Return the updated row
@@ -1699,10 +1700,10 @@ def edit_tag(project, tag_id):
                 updated_row = connection.execute(stmt).first()
 
                 if updated_row is None:
-                    # No row was returned: invalid tag_id or project name
-                    return create_error_response("Update failed: no keyword record with the provided 'tag_id' found in project.")
+                    # No row was returned: invalid keyword_id or project name
+                    return create_error_response(f"Update failed: no keyword with ID '{keyword_id}' found in project.")
 
-                # If the tag is deleted, also delete any events related to it
+                # If the keyword is deleted, also delete any events related to it
                 if "deleted" in values and values["deleted"]:
                     connection_table = get_table("event_connection")
                     occurrence_table = get_table("event_occurrence")
@@ -1716,7 +1717,7 @@ def edit_tag(project, tag_id):
                     # Subquery: Get event IDs for tag_id (used in two of the updates)
                     event_id_subquery = (
                         select(connection_table.c.event_id)
-                        .where(connection_table.c.tag_id == tag_id)
+                        .where(connection_table.c.tag_id == keyword_id)
                     ).scalar_subquery()
 
                     # 1. Update event_occurrence where event_id matches subquery
@@ -1738,7 +1739,7 @@ def edit_tag(project, tag_id):
                     # 3. Update event_connection directly using tag_id filter
                     upd_conn_stmt = (
                         connection_table.update()
-                        .where(connection_table.c.tag_id == tag_id)
+                        .where(connection_table.c.tag_id == keyword_id)
                         .values(**del_upd_value)
                         .returning(connection_table.c.id)
                     )
@@ -1753,7 +1754,7 @@ def edit_tag(project, tag_id):
                 )
 
     except Exception:
-        logger.exception("Exception updating tag.")
+        logger.exception("Exception updating keyword.")
         return create_error_response("Unexpected error: failed to update keyword record.", 500)
 
 
@@ -1980,11 +1981,11 @@ def get_subjects():
     return jsonify(result)
 
 
-@event_tools.route("/tags/")
+@event_tools.route("/keywords/")
 @jwt_required()
-def get_tags():
+def get_keywords():
     """
-    Get all tags from the database
+    Get all keywords from the database
     """
     return select_all_from_table("tag")
 
@@ -2087,7 +2088,7 @@ def add_new_event(project):
       related to.
     - Exactly one of the following:
         - subject_id (int): ID of a person/subject record.
-        - tag_id (int): ID of a keyword/tag record.
+        - tag_id (int): ID of a keyword record.
         - location_id (int): ID of a place/location record.
         - work_manifestation_id (int):  ID of a work title record.
         - correspondence_id (int): ID of a correspondence.

--- a/sls_api/endpoints/tools/events.py
+++ b/sls_api/endpoints/tools/events.py
@@ -1581,7 +1581,7 @@ def edit_tag(project, tag_id):
                 if updated_row is None:
                     # No row was returned: invalid tag_id or project name
                     return create_error_response("Update failed: no keyword record with the provided 'tag_id' found in project.")
-                
+
                 # If the tag is deleted, also delete any events related to it
                 if "deleted" in values and values["deleted"]:
                     connection_table = get_table("event_connection")
@@ -1622,9 +1622,9 @@ def edit_tag(project, tag_id):
                         .returning(connection_table.c.id)
                     )
 
-                    updated_occ_ids = connection.execute(upd_occ_stmt).fetchall()
-                    updated_event_ids = connection.execute(upd_event_stmt).fetchall()
-                    updated_conn_ids = connection.execute(upd_conn_stmt).fetchall()
+                    connection.execute(upd_occ_stmt)
+                    connection.execute(upd_event_stmt)
+                    connection.execute(upd_conn_stmt)
 
                 return create_success_response(
                     message="Keyword record updated.",

--- a/sls_api/endpoints/tools/publications.py
+++ b/sls_api/endpoints/tools/publications.py
@@ -479,19 +479,20 @@ def get_publication_manuscripts(project, publication_id):
         return create_error_response("Unexpected error: failed to retrieve publication manuscripts.", 500)
 
 
-@publication_tools.route("/<project>/publication/<publication_id>/tags/")
+@publication_tools.route("/<project>/publication/<publication_id>/keywords/")
 @jwt_required()
-def get_publication_tags(project, publication_id):
+def get_publication_keywords(project, publication_id):
     """
-    List all (non-deleted) tags/keywords for the specified publication. The
-    tags/keywords are ordered alphabetically by name.
+    List all (non-deleted) keywords for the specified publication. The
+    keywords are ordered alphabetically by name.
+    (Note: keywords are named 'tags' in the database.)
 
     URL Path Parameters:
 
     - project (str, required): The name of the project for which to retrieve
-      publication tags/keywords.
+      publication keywords.
     - publication_id (int, required): The id of the publication to retrieve
-      tags/keywords for. Must be a positive integer.
+      keywords for. Must be a positive integer.
 
     Returns:
 
@@ -506,7 +507,7 @@ def get_publication_tags(project, publication_id):
 
     - `success`: A boolean indicating whether the operation was successful.
     - `message`: A string containing a descriptive message about the result.
-    - `data`: On success, an array of tag/keyword objects with event data;
+    - `data`: On success, an array of keyword objects with event data;
       `null` on error.
 
     Response object keys and their data types:
@@ -529,7 +530,7 @@ def get_publication_tags(project, publication_id):
 
     Example Request:
 
-        GET /projectname/publication/456/tags/
+        GET /projectname/publication/456/keywords/
 
     Example Success Response (HTTP 200):
 
@@ -555,7 +556,7 @@ def get_publication_tags(project, publication_id):
 
     Status Codes:
 
-    - 200 - OK: The request was successful, and the publication tags/keywords
+    - 200 - OK: The request was successful, and the publication keywords
             are returned.
     - 400 - Bad Request: The project name or publication_id is invalid.
     - 500 - Internal Server Error: Database query or execution failed.

--- a/sls_api/endpoints/tools/publications.py
+++ b/sls_api/endpoints/tools/publications.py
@@ -593,7 +593,7 @@ def get_publication_tags(project, publication_id):
             )
         )
         .order_by(
-            collate(tag_table.c.name, "sv-x-icu") # Use Swedish collation for sorting å, ä, ö correctly.
+            collate(tag_table.c.name, "sv-x-icu")  # Use Swedish collation for sorting å, ä, ö correctly.
         )
     )
 

--- a/sls_api/endpoints/tools/publications.py
+++ b/sls_api/endpoints/tools/publications.py
@@ -574,6 +574,8 @@ def get_publication_tags(project, publication_id):
     connection_table = get_table("event_connection")
     occurrence_table = get_table("event_occurrence")
 
+    collation_name = get_project_collation(project)
+
     stmt = (
         select(
             *tag_table.c,
@@ -598,7 +600,7 @@ def get_publication_tags(project, publication_id):
             )
         )
         .order_by(
-            collate(tag_table.c.name, "sv-x-icu")  # Use Swedish collation for sorting å, ä, ö correctly.
+            collate(tag_table.c.name, collation_name)
         )
     )
 


### PR DESCRIPTION
This commit modifies the tools-endpoints for managing tags and events in the database. Endpoints that are modified or added enable:

- listing project tags
- adding new tags to a project
- editing existing tags
- listing tags connected to a publication
- adding new events
- deleting existing events

Event-related tools-endpoints that are not used have been removed.