### PR TITLE
Refactor collection ToC handling

### DIFF
--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -992,20 +992,39 @@ def is_any_valid_date_format(date_string: str) -> bool:
     return False
 
 
-def is_valid_language(lang: str) -> bool:
+def is_valid_language(language_tag: str) -> bool:
     """
-    Validate the language code for use in filenames.
-
-    A valid language code must be 1 to 20 characters long and contain
-    only alphanumeric characters and hyphens.
+    Validate the language tag against a list of base language tags
+    (BCP 47 subset).
 
     Args:
-        lang (str): The language code to validate.
+        language_tag (str): The language tag to validate.
 
     Returns:
-        bool: True if the language code is valid, False otherwise.
+        bool: True if the language tag is valid, False otherwise.
     """
-    return re.fullmatch(r"[a-zA-Z0-9\-]{1,20}", lang) is not None
+    valid_tags = {
+        "ar",  # Arabic
+        "cs",  # Czech
+        "da",  # Danish
+        "de",  # German
+        "el",  # Greek
+        "en",  # English
+        "es",  # Spanish
+        "fi",  # Finnish
+        "fr",  # French
+        "hu",  # Hungarian
+        "is",  # Icelandic
+        "it",  # Italian
+        "la",  # Latin
+        "nl",  # Dutch
+        "no",  # Norwegian
+        "pl",  # Polish
+        "pt",  # Portuguese
+        "ru",  # Russian
+        "sv"   # Swedish
+    }
+    return language_tag in valid_tags
 
 
 def lxml_escape_quotes_if_string(value: Any) -> Any:

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -992,6 +992,22 @@ def is_any_valid_date_format(date_string: str) -> bool:
     return False
 
 
+def is_valid_language(lang: str) -> bool:
+    """
+    Validate the language code for use in filenames.
+
+    A valid language code must be 1 to 20 characters long and contain
+    only alphanumeric characters and hyphens.
+
+    Args:
+        lang (str): The language code to validate.
+
+    Returns:
+        bool: True if the language code is valid, False otherwise.
+    """
+    return re.fullmatch(r"[a-zA-Z0-9\-]{1,20}", lang) is not None
+
+
 def lxml_escape_quotes_if_string(value: Any) -> Any:
     """
     Ensures safe escaping of string values when passing parameters to lxml

--- a/sls_api/endpoints/tools/files.py
+++ b/sls_api/endpoints/tools/files.py
@@ -1061,7 +1061,7 @@ def handle_collection_toc(project, collection_id, language=None):
 
             # Get author and construct git commit message
             author_email = str(identity)
-            author = f"{author_email.split("@")[0]} <{author_email}>"
+            author = f"{author_email.split('@')[0]} <{author_email}>"
             message = f"ToC update by {author_email}"
 
             # git commit (and possibly push) file


### PR DESCRIPTION
This PR creates two separate endpoints for handling collection table of contents:

- In the Tools API (tools/files.py), which requires authentication, the endpoint enables GET and PUT of collection table of contents.
- In the public API (metadata.py), which is used by the edition frontends and doesn't require authentication, the endpoint enables GET of collection table of contents.

Having two separate endpoints instead of one (like before) is motivated because a) it's clearer to not mix non-public endpoints with public ones and to have all the Tools endpoints in a separate set of files; b) the GET responses of the two endpoints differ in format:

- In the tools API the endpoint responds in the standardized way for the frontend CMS.
- In the public API the endpoint responds with the table of contents as a raw string, as currently required by the edition frontends.