### PR TITLE
Tools: add endpoint to get ToC updated with publication data from database

### DIFF
--- a/sls_api/endpoints/tools/files.py
+++ b/sls_api/endpoints/tools/files.py
@@ -1215,7 +1215,7 @@ def get_collection_toc_updated_from_db(project, collection_id, language=None):
 
     # Validate language
     if language is not None and not is_valid_language(language):
-        return create_error_response("Validation error: 'language' can only contain alphanumeric characters and hyphens, and can’t be more than 20 characters long.")
+        return create_error_response("Validation error: 'language' is not among valid language codes.")
 
     # Validate request data
     payload = request.get_json()
@@ -1298,6 +1298,7 @@ def get_collection_toc_updated_from_db(project, collection_id, language=None):
     # Build update map
     update_map = {}
     for row in publication_rows:
+        row = row._asdict()
         item_id = f"{collection_id}_{row['id']}"
         entry = {}
 

--- a/sls_api/endpoints/tools/files.py
+++ b/sls_api/endpoints/tools/files.py
@@ -1146,7 +1146,7 @@ def get_collection_toc_updated_from_db(project, collection_id, language=None):
     Get an existing table of contents for the specified collection in the
     specified language (optional) and project, with publication names
     and dates updated from the database.
-    
+
     Note: This endpoint does not modify the table of contents file in the
     project repository – it simply loads the table of contents on the
     server, updates it with the latest publication data in the database,
@@ -1290,7 +1290,7 @@ def get_collection_toc_updated_from_db(project, collection_id, language=None):
 
     except Exception:
         logger.exception("Exception retrieving publications data for collection ToC update.")
-        return create_error_response("Unexpected error: failed to retrieve publications data.", 500)  
+        return create_error_response("Unexpected error: failed to retrieve publications data.", 500)
 
     if len(publication_rows) == 0:
         return create_error_response(f"No publications in collection with ID '{collection_id}'.")

--- a/sls_api/endpoints/tools/files.py
+++ b/sls_api/endpoints/tools/files.py
@@ -1039,7 +1039,7 @@ def handle_collection_toc(project, collection_id, language=None):
 
     # Validate language
     if language is not None and not is_valid_language(language):
-        return create_error_response("Validation error: 'language' can only contain alphanumeric characters and hyphens, and can’t be more than 20 characters long.")
+        return create_error_response("Validation error: 'language' is not among valid language codes.")
 
     filename = f"{collection_id}_{language}.json" if language else f"{collection_id}.json"
     filepath = safe_join(config["file_root"], "toc", filename)


### PR DESCRIPTION
Adds a new endpoint, which can be used to update the names and dates of publications in a collection table of contents with the latest data in the database.

The endpoint responds with the updated ToC, but does not save it on the server. The idea is that the frontend can use the endpoint to get the updated ToC, then the frontend user can review the changes before saving them.