### PR TITLE
Tools: fix accessing return rows in event handling

### DIFF
--- a/sls_api/exceptions.py
+++ b/sls_api/exceptions.py
@@ -9,6 +9,7 @@ class CascadeUpdateError(Exception):
         super().__init__(message)
         self.message = message
 
+
 class DeleteError(Exception):
     def __init__(self, message: str, status=400):
         super().__init__(message)

--- a/sls_api/exceptions.py
+++ b/sls_api/exceptions.py
@@ -8,3 +8,9 @@ class CascadeUpdateError(Exception):
     def __init__(self, message: str):
         super().__init__(message)
         self.message = message
+
+class DeleteError(Exception):
+    def __init__(self, message: str, status=400):
+        super().__init__(message)
+        self.message = message
+        self.status = status


### PR DESCRIPTION
Previously I tried to access the fields of tuple-like return rows with strings, which caused a TypeError. Now added `mappings()` so SQLAlchemy returns dict-like rows. Also other minor improvements to how result rows are fetched and exception handling in the two endpoints that handle events.