### PR TITLE
Cleanup and dependency upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,19 +5,15 @@ FROM python:3.13-slim-bookworm
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
-# build-essential is needed to build some libraries (mainly uwsgi and the various database support ones)
+# build-essential is needed to build psycopg and uwsgi
 # git is needed to pull/push file changes
 # imagemagick is needed for conversions as part of facsimile upload
-# libmariadb-dev is needed to build mysqlclient for mysql/mariadb support
-# libpq-dev is needed for proper postgresql support
-# pkg-config is required to build mysqlclient
+# libpq-dev is needed to build psycopg from source
 RUN apt update && apt install -y \
     build-essential \
     git \
     imagemagick \
-    libmariadb-dev \
-    libpq-dev \
-    pkg-config
+    libpq-dev
 
 # create uwsgi user for uWSGI to run as (running as root is a Bad Idea, generally)
 RUN useradd -ms /bin/bash uwsgi

--- a/setup.py
+++ b/setup.py
@@ -3,26 +3,26 @@ from setuptools import setup
 setup(
     name='sls_api',
     packages=['sls_api'],
-    version="1.4.1",
+    version="1.5.0",
     include_package_data=True,
     install_requires=[
         'argon2-cffi==25.1.0',
-        'beautifulsoup4==4.13.5',
+        'beautifulsoup4==4.14.3',
         'elasticsearch==7.17.12',
         'flask==3.1.2',
         'flask-jwt-extended==4.7.1',
         'flask-sqlalchemy==3.1.1',
-        'flask-cors==6.0.1',
-        'lxml==6.0.1',
-        'mysqlclient==2.2.7',
+        'flask-cors==6.0.2',
+        'lxml==6.0.2',
         'passlib==1.7.4',
-        'Pillow==11.3.0',
-        'psycopg2-binary==2.9.10',
-        'ruamel.yaml==0.18.15',
+        'Pillow==12.0.0',
+        'psycopg2==2.9.11',
+        'PyMySQL==1.1.2',
+        'ruamel.yaml==0.18.17',
         'requests==2.32.5',
-        'saxonche==12.8.0',
-        'sqlalchemy==2.0.43',
-        'werkzeug==3.1.3',
-        'uwsgi==2.0.30'
+        'saxonche==12.9.0',
+        'sqlalchemy==2.0.45',
+        'werkzeug==3.1.4',
+        'uwsgi==2.0.31'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
         'passlib==1.7.4',
         'Pillow==11.3.0',
         'psycopg2-binary==2.9.10',
-        'raven[flask]==6.10.0',
         'ruamel.yaml==0.18.15',
         'requests==2.32.5',
         'saxonche==12.8.0',

--- a/sls_api/__init__.py
+++ b/sls_api/__init__.py
@@ -99,6 +99,8 @@ if projects_config_exists and security_config_exists:
     app.register_blueprint(collection_tools, url_prefix="/digitaledition")
     from sls_api.endpoints.tools.events import event_tools
     app.register_blueprint(event_tools, url_prefix="/digitaledition")
+    from sls_api.endpoints.tools.facsimiles import facsimile_tools
+    app.register_blueprint(facsimile_tools, url_prefix="/digitaledition")
     from sls_api.endpoints.tools.files import file_tools
     app.register_blueprint(file_tools, url_prefix="/digitaledition")
     from sls_api.endpoints.tools.groups import group_tools

--- a/sls_api/__init__.py
+++ b/sls_api/__init__.py
@@ -3,7 +3,6 @@ from flask_jwt_extended import JWTManager
 from flask_cors import CORS
 import logging
 import os
-from raven.contrib.flask import Sentry
 from ruamel.yaml import YAML
 from sys import stdout
 
@@ -22,21 +21,6 @@ stream_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(leveln
 root_logger.addHandler(stream_handler)
 
 logger = logging.getLogger("sls_api")
-
-# if there's a sentry.io config file, enable error tracking towards it
-if os.path.exists(os.path.join("sls_api", "configs", "sentry.yml")):
-    with open(os.path.join("sls_api", "configs", "sentry.yml")) as config_file:
-        sentry_config = yaml.load(config_file.read())
-        # handle environment variables in the YAML file
-        for setting, value in sentry_config.items():
-            sentry_config[setting] = os.path.expandvars(value)
-    if "sentry_dsn" in sentry_config and sentry_config["sentry_dsn"] != "":
-        logger.info("Enabled sentry.io error tracking with settings from 'sentry.yml'")
-        sentry = Sentry(app, dsn=sentry_config["sentry_dsn"], logging=True, level=logging.ERROR)
-    else:
-        sentry = None
-else:
-    sentry = None
 
 # check what config files exists, so we know what blueprints to load
 projects_config_exists = os.path.exists(os.path.join("sls_api", "configs", "digital_editions.yml"))

--- a/sls_api/configs/sentry_example.yml
+++ b/sls_api/configs/sentry_example.yml
@@ -1,2 +1,0 @@
-# Config settings for sentry.io error tracking software
-sentry_dsn: 'https://public_key:secret_key@example.com/1'

--- a/sls_api/endpoints/facsimiles.py
+++ b/sls_api/endpoints/facsimiles.py
@@ -1,15 +1,10 @@
 from flask import Blueprint, jsonify, request, Response
 import io
 import logging
-import os
 import sqlalchemy
-import subprocess
 from werkzeug.security import safe_join
-from werkzeug.utils import secure_filename
 
-from sls_api.endpoints.generics import ALLOWED_EXTENSIONS_FOR_FACSIMILE_UPLOAD, allowed_facsimile, db_engine, \
-    FACSIMILE_IMAGE_SIZES, FACSIMILE_UPLOAD_FOLDER, get_project_config, get_project_id_from_name, \
-    project_permission_required
+from sls_api.endpoints.generics import db_engine, get_project_config, get_project_id_from_name
 
 facsimiles = Blueprint('facsimiles', __name__)
 logger = logging.getLogger("sls_api.facsimiles")
@@ -124,95 +119,6 @@ def get_facsimile_collections(project, facsimile_collection_ids):
             return_data.append(row._asdict())
     connection.close()
     return jsonify(return_data), 200
-
-
-def convert_resize_uploaded_facsimile(uploaded_file_path, collection_folder_path, page_number):
-    """
-    Given an uploaded file, a destination folder for the facsimile collection, and a page number - create a .jpg file for each zoom level for the page
-    Files are stored as <collection_folder_path>/<zoom_level>/<page_number>.jpg
-    Where zoom_level is determined by FACSIMILE_IMAGE_SIZES in generics.py (1-4)
-
-    Returns True if all conversions succeeded, otherwise returns False.
-    """
-    successful_conversions = []
-    for zoom_level, resolution in FACSIMILE_IMAGE_SIZES.items():
-        os.makedirs(safe_join(collection_folder_path, str(zoom_level)), exist_ok=True)
-        convert_cmd = ["convert", "-resize", resolution, "-quality", "77", "-colorspace", "sRGB",
-                       uploaded_file_path, safe_join(collection_folder_path, str(zoom_level), f"{page_number}.jpg")]
-        try:
-            subprocess.run(convert_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
-        except subprocess.CalledProcessError as ex:
-            logger.exception("Failed to convert uploaded facsimile!")
-            logger.error(ex.stdout)
-            logger.error(ex.stderr)
-        else:
-            successful_conversions.append(str(zoom_level))
-    # remove uploaded source file once conversions are complete
-    os.remove(uploaded_file_path)
-    return len(successful_conversions) == len(FACSIMILE_IMAGE_SIZES.keys())
-
-
-@project_permission_required
-@facsimiles.route("/<project>/facsimiles/<collection_id>/<page_number>", methods=["PUT", "POST"])
-def upload_facsimile_file(project, collection_id, page_number):
-    """
-    Upload a facsimile file in image format.
-
-    Endpoint accepts requests with enctype=multipart/form-data
-    Endpoint assumes facsimile is provided as form parameter named 'facsimile'
-    (for example, curl -F 'facsimile=@path/to/local/file' https://api.sls.fi/digitaledition/<project>/facsimiles/<collection_id>/<page_number>)
-
-    ---
-    First and foremost, only accept images. Reject with 400 anything that allowed_facsimile() doesn't accept.
-    Then, attempt to convert image to 4 different "zoom levels" of .jpg with imagemagick
-
-    Lastly, store the images in root/facsimiles/<collection_id>/<zoom_level>/<page_number>.jpg
-    Where zoom_level is determined by FACSIMILE_IMAGE_SIZES in generics.py (1-4)
-    """
-    # TODO OpenStack Swift support for ISILON file storage - config param for root 'facsimiles' path
-    # ensure temporary facsimile upload folder exists
-    os.makedirs(FACSIMILE_UPLOAD_FOLDER, exist_ok=True)
-    config = get_project_config(project)
-    if config is None:
-        return jsonify({"msg": "No such project."}), 400
-    if request.files is None:
-        return jsonify({"msg": "Request.files is none!"}), 400
-    if "facsimile" not in request.files:
-        return jsonify({"msg": "No file provided in request (facsimile)!"}), 400
-    # get a folder path for the facsimile collection from the database if set, otherwise use project file root
-    connection = db_engine.connect()
-    collection_check_statement = sqlalchemy.sql.text("SELECT * FROM publication_facsimile_collection WHERE deleted != 1 AND id=:coll_id").bindparams(coll_id=collection_id)
-    row = connection.execute(collection_check_statement).fetchone()
-    if row is None:
-        return jsonify({
-            "msg": "Desired facsimile collection was not found in database!"
-        }), 404
-    elif row.folder_path != '' and row.folder_path is not None:
-        collection_folder_path = safe_join(row.folder_path, collection_id)
-    else:
-        collection_folder_path = safe_join(config["file_root"], "facsimiles", collection_id)
-    connection.close()
-
-    # handle received file
-    uploaded_file = request.files["facsimile"]
-    # if user selects no file, some libraries send a POST with an empty file and filename
-    if uploaded_file.filename == "":
-        return jsonify({"msg": "No file provided in uploaded_file.filename!"}), 400
-
-    if uploaded_file and allowed_facsimile(uploaded_file.filename):
-        # handle potentially malicious filename and save file to temp folder
-        temp_path = os.path.join(FACSIMILE_UPLOAD_FOLDER, secure_filename(uploaded_file.filename))
-        uploaded_file.save(temp_path)
-
-        # resize file using imagemagick
-        resize = convert_resize_uploaded_facsimile(temp_path, collection_folder_path, page_number)
-
-        if resize:
-            return jsonify({"msg": "OK"})
-        else:
-            return jsonify({"msg": "Failed to resize uploaded facsimile!"}), 500
-    else:
-        return jsonify({"msg": f"Invalid facsimile provided. Allowed filetypes are {ALLOWED_EXTENSIONS_FOR_FACSIMILE_UPLOAD}. TIFF files are preferred."}), 400
 
 
 @facsimiles.route("/<project>/facsimiles/<collection_id>/<number>/<zoom_level>")

--- a/sls_api/endpoints/tools/facsimiles.py
+++ b/sls_api/endpoints/tools/facsimiles.py
@@ -1,0 +1,103 @@
+from flask import Blueprint, jsonify, request
+import logging
+import os
+import sqlalchemy
+import subprocess
+from werkzeug.security import safe_join
+from werkzeug.utils import secure_filename
+
+from sls_api.endpoints.generics import ALLOWED_EXTENSIONS_FOR_FACSIMILE_UPLOAD, allowed_facsimile, db_engine, \
+    FACSIMILE_IMAGE_SIZES, FACSIMILE_UPLOAD_FOLDER, get_project_config, project_permission_required
+
+
+facsimile_tools = Blueprint('facsimile_tools', __name__)
+logger = logging.getLogger("sls_api.tools.facsimiles")
+
+
+def convert_resize_uploaded_facsimile(uploaded_file_path, collection_folder_path, page_number):
+    """
+    Given an uploaded file, a destination folder for the facsimile collection, and a page number - create a .jpg file for each zoom level for the page
+    Files are stored as <collection_folder_path>/<zoom_level>/<page_number>.jpg
+    Where zoom_level is determined by FACSIMILE_IMAGE_SIZES in generics.py (1-4)
+
+    Returns True if all conversions succeeded, otherwise returns False.
+    """
+    successful_conversions = []
+    for zoom_level, resolution in FACSIMILE_IMAGE_SIZES.items():
+        os.makedirs(safe_join(collection_folder_path, str(zoom_level)), exist_ok=True)
+        convert_cmd = ["convert", "-resize", resolution, "-quality", "77", "-colorspace", "sRGB",
+                       uploaded_file_path, safe_join(collection_folder_path, str(zoom_level), f"{page_number}.jpg")]
+        try:
+            subprocess.run(convert_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+        except subprocess.CalledProcessError as ex:
+            logger.exception("Failed to convert uploaded facsimile!")
+            logger.error(ex.stdout)
+            logger.error(ex.stderr)
+        else:
+            successful_conversions.append(str(zoom_level))
+    # remove uploaded source file once conversions are complete
+    os.remove(uploaded_file_path)
+    return len(successful_conversions) == len(FACSIMILE_IMAGE_SIZES.keys())
+
+
+@project_permission_required
+@facsimile_tools.route("/<project>/facsimiles/<collection_id>/<page_number>", methods=["PUT", "POST"])
+def upload_facsimile_file(project, collection_id, page_number):
+    """
+    Upload a facsimile file in image format.
+
+    Endpoint accepts requests with enctype=multipart/form-data
+    Endpoint assumes facsimile is provided as form parameter named 'facsimile'
+    (for example, curl -F 'facsimile=@path/to/local/file' https://api.sls.fi/digitaledition/<project>/facsimiles/<collection_id>/<page_number>)
+
+    ---
+    First and foremost, only accept images. Reject with 400 anything that allowed_facsimile() doesn't accept.
+    Then, attempt to convert image to 4 different "zoom levels" of .jpg with imagemagick
+
+    Lastly, store the images in root/facsimiles/<collection_id>/<zoom_level>/<page_number>.jpg
+    Where zoom_level is determined by FACSIMILE_IMAGE_SIZES in generics.py (1-4)
+    """
+    # TODO OpenStack Swift support for ISILON file storage - config param for root 'facsimiles' path
+    # ensure temporary facsimile upload folder exists
+    os.makedirs(FACSIMILE_UPLOAD_FOLDER, exist_ok=True)
+    config = get_project_config(project)
+    if config is None:
+        return jsonify({"msg": "No such project."}), 400
+    if request.files is None:
+        return jsonify({"msg": "Request.files is none!"}), 400
+    if "facsimile" not in request.files:
+        return jsonify({"msg": "No file provided in request (facsimile)!"}), 400
+    # get a folder path for the facsimile collection from the database if set, otherwise use project file root
+    connection = db_engine.connect()
+    collection_check_statement = sqlalchemy.sql.text("SELECT * FROM publication_facsimile_collection WHERE deleted != 1 AND id=:coll_id").bindparams(coll_id=collection_id)
+    row = connection.execute(collection_check_statement).fetchone()
+    if row is None:
+        return jsonify({
+            "msg": "Desired facsimile collection was not found in database!"
+        }), 404
+    elif row.folder_path != '' and row.folder_path is not None:
+        collection_folder_path = safe_join(row.folder_path, collection_id)
+    else:
+        collection_folder_path = safe_join(config["file_root"], "facsimiles", collection_id)
+    connection.close()
+
+    # handle received file
+    uploaded_file = request.files["facsimile"]
+    # if user selects no file, some libraries send a POST with an empty file and filename
+    if uploaded_file.filename == "":
+        return jsonify({"msg": "No file provided in uploaded_file.filename!"}), 400
+
+    if uploaded_file and allowed_facsimile(uploaded_file.filename):
+        # handle potentially malicious filename and save file to temp folder
+        temp_path = os.path.join(FACSIMILE_UPLOAD_FOLDER, secure_filename(uploaded_file.filename))
+        uploaded_file.save(temp_path)
+
+        # resize file using imagemagick
+        resize = convert_resize_uploaded_facsimile(temp_path, collection_folder_path, page_number)
+
+        if resize:
+            return jsonify({"msg": "OK"})
+        else:
+            return jsonify({"msg": "Failed to resize uploaded facsimile!"}), 500
+    else:
+        return jsonify({"msg": f"Invalid facsimile provided. Allowed filetypes are {ALLOWED_EXTENSIONS_FOR_FACSIMILE_UPLOAD}. TIFF files are preferred."}), 400

--- a/sls_api/endpoints/tools/files.py
+++ b/sls_api/endpoints/tools/files.py
@@ -222,34 +222,6 @@ def normalize_toc_key_order(node, *, children_key: str = "children"):
     return node
 
 
-@file_tools.route("/<project>/config/get")
-def get_config_file(project):
-    config = get_project_config(project)
-    if config is None:
-        return jsonify({"msg": "No such project."}), 400
-    else:
-        file_path = os.path.join(config["file_root"], "config.json")
-        if not os.path.exists(file_path):
-            return jsonify({})
-        with open(file_path) as f:
-            json_data = json.load(f)
-        return jsonify(json_data)
-
-
-@file_tools.route("/<project>/config/update", methods=["POST"])
-@project_permission_required
-def update_config(project):
-    config = get_project_config(project)
-    if config is None:
-        return jsonify({"msg": "No such project."}), 400
-    else:
-        request_data = request.get_json()
-        file_path = os.path.join(config["file_root"], "config.json")
-        with open(file_path, "w") as f:
-            json.dump(request_data, f)
-        return jsonify({"msg": "received"})
-
-
 @file_tools.route("/<project>/git-repo-details")
 @project_permission_required
 def get_git_repo_details(project):


### PR DESCRIPTION
This PR removes the following:

- sentry.io support
- config file management in tools/files.py

It also moves the facsimile upload code from facsimiles.py to tools/facsimiles.py, and registers this new blueprint.

Dependencies are also upgraded to latest versions, apart from Elasticsearch, which still needs to be tested against an updated ES server to ensure it works with ES 9.x
To simplify the build process somewhat, mysqlclient was also replaced by PyMySQL. This shouldn't impact anything, though comments-stuff that uses the comments_database may need to be tested to ensure nothing changed.