### PR TITLE
Add publication metadata endpoint

### DIFF
--- a/sls_api/configs/digital_editions_example.yml
+++ b/sls_api/configs/digital_editions_example.yml
@@ -47,14 +47,14 @@ topelius:
     # as web XML files when it runs, and the API endpoints serve the
     # prerendered HTML files (as a fallback, the HTML is transformed on the
     # fly from XML if the prerendered HTML files are missing or can’t be read).
-    # Defaults to `False`.
+    # Defaults to `False` if missing.
     prerender_html: False
     # Boolean indicating if JSON data prerendering is enabled for the project.
-    # Currently used for publication metadata JSON. Defaults to `False`.
+    # Currently used for publication metadata JSON. Defaults to `False` if missing.
     prerender_json: False
     # Frontend languages for this project. The publisher uses these language
     # codes when prerendering language-specific JSON files, such as publication
-    # metadata.
+    # metadata. Defaults to `["sv"]` if missing.
     frontend_languages: ["sv"]
     # Boolean indicating if chapter divisions are used in the project’s
     # XML texts or not. Defaults to `True`.

--- a/sls_api/configs/digital_editions_example.yml
+++ b/sls_api/configs/digital_editions_example.yml
@@ -49,6 +49,13 @@ topelius:
     # fly from XML if the prerendered HTML files are missing or can’t be read).
     # Defaults to `False`.
     prerender_html: False
+    # Boolean indicating if JSON data prerendering is enabled for the project.
+    # Currently used for publication metadata JSON. Defaults to `False`.
+    prerender_json: False
+    # Frontend languages for this project. The publisher uses these language
+    # codes when prerendering language-specific JSON files, such as publication
+    # metadata.
+    frontend_languages: ["sv"]
     # Boolean indicating if chapter divisions are used in the project’s
     # XML texts or not. Defaults to `True`.
     xml_chapter_divs: True

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -507,9 +507,24 @@ def cache_is_recent(source_file, xsl_file, cache_file):
     return True
 
 
+def resolve_project_published_threshold(project_config: Mapping) -> int:
+    """
+    Return the lowest published status visible for a project.
+
+    Status values are cumulative: ``0`` means unpublished content can be shown,
+    ``1`` means internally published content can be shown, and ``2`` means only
+    externally published content can be shown.
+    """
+    if project_config.get("show_unpublished", False):
+        return 0
+    if project_config.get("show_internally_published", False):
+        return 1
+    return 2
+
+
 def can_show_published_values(
         published_values: List[Optional[int]],
-        show_published_status: int
+        show_published_threshold: int
 ) -> Tuple[bool, str]:
     """
     Determine whether content with one or more published-status values
@@ -528,7 +543,8 @@ def can_show_published_values(
 
     Args:
         published_values: Published-status values to evaluate.
-        show_published_status: Lowest published status visible for the project.
+        show_published_threshold: Lowest published status visible for
+            the project.
 
     Returns:
         A tuple of (can_show, message), where message is empty if the
@@ -540,27 +556,12 @@ def can_show_published_values(
         else min(published_values)
     )
 
-    if status >= show_published_status:
+    if status >= show_published_threshold:
         return True, ""
     elif status < 1:
         return False, "Content is not published."
     else:
         return False, "Content is not publicly available."
-
-
-def resolve_project_published_threshold(project_config: Mapping) -> int:
-    """
-    Return the lowest published status visible for a project.
-
-    Status values are cumulative: ``0`` means unpublished content can be shown,
-    ``1`` means internally published content can be shown, and ``2`` means only
-    externally published content can be shown.
-    """
-    if project_config.get("show_unpublished", False):
-        return 0
-    if project_config.get("show_internally_published", False):
-        return 1
-    return 2
 
 
 def get_published_status(
@@ -1037,7 +1038,7 @@ def get_publication_metadata_base_row(
 
     The row includes the published status values needed for visibility checks.
     """
-    show_published_status = resolve_project_published_threshold(project_config)
+    show_published_threshold = resolve_project_published_threshold(project_config)
 
     try:
         project_table = get_table("project")
@@ -1087,7 +1088,7 @@ def get_publication_metadata_base_row(
                                 comment_table.c.id
                             ),
                             comment_table.c.deleted < 1,
-                            comment_table.c.published >= show_published_status
+                            comment_table.c.published >= show_published_threshold
                         )
                     )
                     .outerjoin(
@@ -1170,7 +1171,7 @@ def get_publication_metadata_from_db(
     if not can_show:
         return None, message, 403
 
-    show_published_status = resolve_project_published_threshold(project_config)
+    show_published_threshold = resolve_project_published_threshold(project_config)
 
     try:
         manuscript_table = get_table("publication_manuscript")
@@ -1193,7 +1194,7 @@ def get_publication_metadata_from_db(
                 .where(manuscript_table.c.publication_id == publication_id)
                 .where(manuscript_table.c.deleted < 1)
                 .where(
-                    manuscript_table.c.published >= show_published_status
+                    manuscript_table.c.published >= show_published_threshold
                 )
                 .order_by(
                     manuscript_table.c.sort_order,
@@ -1219,7 +1220,7 @@ def get_publication_metadata_from_db(
                 .where(variant_table.c.publication_id == publication_id)
                 .where(variant_table.c.deleted < 1)
                 .where(
-                    variant_table.c.published >= show_published_status
+                    variant_table.c.published >= show_published_threshold
                 )
                 .order_by(
                     variant_table.c.sort_order,

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -492,6 +492,48 @@ def cache_is_recent(source_file, xsl_file, cache_file):
     return True
 
 
+def can_show_published_values(
+        published_values: List[Optional[int]],
+        show_internally_published: bool
+) -> Tuple[bool, str]:
+    """
+    Determine whether content with one or more published-status values
+    should be visible.
+
+    Published status is evaluated across all relevant database rows, for
+    example project, collection, and publication. The lowest status wins:
+    if any part of the chain is unpublished, the content is unpublished;
+    if the lowest status is internally published, visibility depends on
+    the project's `show_internally_published` setting.
+
+    Status values:
+        - None or values below 1: unpublished
+        - 1: internally published
+        - 2 or higher: publicly available
+
+    Args:
+        published_values: Published-status values to evaluate.
+        show_internally_published: Whether internally published content
+            should be visible for this project.
+
+    Returns:
+        A tuple of (can_show, message), where message is empty if the
+        content can be shown.
+    """
+    status = (
+        -1
+        if not published_values or any(v is None for v in published_values)
+        else min(published_values)
+    )
+
+    if status < 1:
+        return False, "Content is not published."
+    elif status == 1 and not show_internally_published:
+        return False, "Content is not publicly available."
+    else:
+        return True, ""
+
+
 def get_published_status(
         project: str,
         collection_id: str,
@@ -589,14 +631,7 @@ def get_published_status(
         if publication_id is not None:
             pub_values.append(row["pub"])
 
-        status = -1 if any(v is None for v in pub_values) else min(pub_values)
-
-        if status < 1:
-            message = "Content is not published."
-        elif status == 1 and not show_internal:
-            message = "Content is not publicly available."
-        else:
-            can_show = True
+        can_show, message = can_show_published_values(pub_values, show_internal)
 
     return can_show, message, col_legacy_id
 

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -549,6 +549,21 @@ def can_show_published_values(
         return True, ""
 
 
+def get_show_published_status(project_config: Mapping) -> int:
+    """
+    Return the lowest published status visible for a project.
+
+    Status values are cumulative: ``0`` means unpublished content can be shown,
+    ``1`` means internally published content can be shown, and ``2`` means only
+    externally published content can be shown.
+    """
+    if project_config.get("show_unpublished", False):
+        return 0
+    if project_config.get("show_internally_published", False):
+        return 1
+    return 2
+
+
 def get_published_status(
         project: str,
         collection_id: str,
@@ -1011,9 +1026,7 @@ def get_publication_metadata_base_row(
 
     The row includes the published status values needed for visibility checks.
     """
-    show_published_status = (
-        1 if project_config.get("show_internally_published", False) else 2
-    )
+    show_published_status = get_show_published_status(project_config)
 
     try:
         project_table = get_table("project")
@@ -1147,9 +1160,7 @@ def get_publication_metadata_from_db(
     if not can_show:
         return None, message, 403
 
-    show_published_status = (
-        1 if project_config.get("show_internally_published", False) else 2
-    )
+    show_published_status = get_show_published_status(project_config)
 
     try:
         manuscript_table = get_table("publication_manuscript")

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -1003,17 +1003,23 @@ def get_project_frontend_languages(project_config: Mapping) -> List[str]:
 def get_publication_metadata_base_row(
         project: str,
         publication_id: int,
-        language: str
+        language: str,
+        project_config: Mapping
 ) -> Tuple[Optional[RowMapping], str, int]:
     """
     Fetch the publication and collection row used by publication metadata.
 
     The row includes the published status values needed for visibility checks.
     """
+    show_published_status = (
+        1 if project_config.get("show_internally_published", False) else 2
+    )
+
     try:
         project_table = get_table("project")
         collection_table = get_table("publication_collection")
         publication_table = get_table("publication")
+        comment_table = get_table("publication_comment")
         translation_text_table = get_table("translation_text")
 
         with db_engine.connect() as connection:
@@ -1036,6 +1042,7 @@ def get_publication_metadata_base_row(
                         "publication_date"
                     ),
                     publication_table.c.language.label("publication_language"),
+                    comment_table.c.original_filename.label("comment_filepath"),
                 )
                 .select_from(
                     project_table
@@ -1047,6 +1054,16 @@ def get_publication_metadata_base_row(
                         publication_table,
                         publication_table.c.publication_collection_id == (
                             collection_table.c.id
+                        )
+                    )
+                    .outerjoin(
+                        comment_table,
+                        and_(
+                            publication_table.c.publication_comment_id == (
+                                comment_table.c.id
+                            ),
+                            comment_table.c.deleted < 1,
+                            comment_table.c.published >= show_published_status
                         )
                     )
                     .outerjoin(
@@ -1117,7 +1134,8 @@ def get_publication_metadata_from_db(
         base_row, message, status_code = get_publication_metadata_base_row(
             project,
             publication_id,
-            language
+            language,
+            project_config
         )
         if base_row is None:
             return None, message, status_code
@@ -1252,6 +1270,7 @@ def get_publication_metadata_from_db(
         "publication_genre": base_row["publication_genre"],
         "publication_date": base_row["publication_date"],
         "publication_language": base_row["publication_language"],
+        "comment_filepath": base_row["comment_filepath"],
         "collection_id": base_row["collection_id"],
         "collection_title": base_row["collection_title"],
         "facsimiles": facsimiles,
@@ -1368,7 +1387,11 @@ def construct_publication_metadata_response(
     """
     file_root = project_config.get("file_root", "")
     relative_xsl_path = XSL_PATH_MAP_FOR_JSON_TRANSFORMATIONS.get("publication_metadata")
-    xml_path_fields = ["publication_filepath", "original_filename"]
+    xml_path_fields = [
+        "publication_filepath",
+        "comment_filepath",
+        "original_filename"
+    ]
     if saxon_processor is None:
         saxon_processor = saxon_proc
         if xslt_processor is None:

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -509,7 +509,7 @@ def cache_is_recent(source_file, xsl_file, cache_file):
 
 def can_show_published_values(
         published_values: List[Optional[int]],
-        show_internally_published: bool
+        show_published_status: int
 ) -> Tuple[bool, str]:
     """
     Determine whether content with one or more published-status values
@@ -517,19 +517,18 @@ def can_show_published_values(
 
     Published status is evaluated across all relevant database rows, for
     example project, collection, and publication. The lowest status wins:
-    if any part of the chain is unpublished, the content is unpublished;
-    if the lowest status is internally published, visibility depends on
-    the project's `show_internally_published` setting.
+    if any part of the chain has a status below the project's effective
+    show-published threshold, the content cannot be shown.
 
     Status values:
-        - None or values below 1: unpublished
+        - None: invalid/missing published status
+        - 0: unpublished
         - 1: internally published
         - 2 or higher: publicly available
 
     Args:
         published_values: Published-status values to evaluate.
-        show_internally_published: Whether internally published content
-            should be visible for this project.
+        show_published_status: Lowest published status visible for the project.
 
     Returns:
         A tuple of (can_show, message), where message is empty if the
@@ -541,12 +540,12 @@ def can_show_published_values(
         else min(published_values)
     )
 
-    if status < 1:
-        return False, "Content is not published."
-    elif status == 1 and not show_internally_published:
-        return False, "Content is not publicly available."
-    else:
+    if status >= show_published_status:
         return True, ""
+    elif status < 1:
+        return False, "Content is not published."
+    else:
+        return False, "Content is not publicly available."
 
 
 def get_show_published_status(project_config: Mapping) -> int:
@@ -588,6 +587,9 @@ def get_published_status(
     Collections/publications can be shown if they're externally
     published (published==2), or if they're internally published
     (published==1) and show_internally_published is True
+
+    TODO: Change this to use ``get_show_published_status(project_config)``
+    so ``show_unpublished`` is handled consistently with newer endpoints.
     """
     project_config = get_project_config(project)
     if project_config is None:
@@ -648,7 +650,9 @@ def get_published_status(
         logger.exception(message)
         return False, message, None
 
-    show_internal = project_config["show_internally_published"]
+    show_published_status = (
+        1 if project_config["show_internally_published"] else 2
+    )
     can_show = False
     message = ""
     col_legacy_id = None
@@ -661,7 +665,10 @@ def get_published_status(
         if publication_id is not None:
             pub_values.append(row["pub"])
 
-        can_show, message = can_show_published_values(pub_values, show_internal)
+        can_show, message = can_show_published_values(
+            pub_values,
+            show_published_status
+        )
 
     return can_show, message, col_legacy_id
 
@@ -1118,14 +1125,13 @@ def can_show_publication_metadata_row(
     """
     Return whether the publication metadata row passes visibility checks.
     """
-    show_internal = project_config.get("show_internally_published", False)
     return can_show_published_values(
         [
             row["project_published"],
             row["collection_published"],
             row["publication_published"]
         ],
-        show_internal
+        get_show_published_status(project_config)
     )
 
 

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -7,18 +7,20 @@ from functools import wraps
 import glob
 import hashlib
 import io
+import json
 import logging
 from lxml import etree
-from saxonche import PySaxonProcessor, PyXslt30Processor, PyXsltExecutable
 import os
+from pathlib import Path
 import re
 from ruamel.yaml import YAML
+from saxonche import PySaxonProcessor, PyXslt30Processor, PyXsltExecutable
 from sls_api.models import User
 from sqlalchemy import create_engine, Connection, MetaData, RowMapping, Table
 from sqlalchemy.sql import and_, select, text
 from sqlalchemy.sql.selectable import Select
 import time
-from typing import Any, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, Union
 from werkzeug.security import safe_join
 
 from sls_api.scripts.saxon_xml_document import SaxonXMLDocument
@@ -47,9 +49,9 @@ DEFAULT_COLLATION = "sv-x-icu"  # Generic Swedish Unicode collation
 # HTML than prerendered HTML from the XML files).
 PRERENDERED_HTML_PATH_IN_PROJECT_ROOT = "html/documents"
 
-# Map of paths to XSLT stylesheets for HTML transformations for different
-# text types. The paths to the XSLT stylesheets are relative to the
-# project root.
+# Map of paths to XSLT stylesheets for XML->HTML transformations for
+# different text types. The paths to the XSLT stylesheets are relative
+# to the project root.
 XSL_PATH_MAP_FOR_HTML_TRANSFORMATIONS = {
     "com": "xslt/com.xsl",
     "est": "xslt/est.xsl",
@@ -60,6 +62,13 @@ XSL_PATH_MAP_FOR_HTML_TRANSFORMATIONS = {
     "tit": "xslt/title.xsl",
     "var_base": "xslt/poem_variants_est.xsl",
     "var_other": "xslt/poem_variants_other.xsl"
+}
+
+# Map of paths to XSLT stylesheets for XML->JSON transformations for
+# different text types. The paths to the XSLT stylesheets are relative
+# to the project root.
+XSL_PATH_MAP_FOR_JSON_TRANSFORMATIONS = {
+    "publication_metadata": "xslt/publication-metadata.xsl"
 }
 
 # Frontend URL used in links sent over email (address verification, password reset)
@@ -959,6 +968,70 @@ def get_frontmatter_page_content(
     )
 
 
+def construct_publication_metadata_response(
+        db_metadata: Dict[str, Any],
+        project_config: Mapping
+) -> Tuple[Dict[str, Any], int]:
+    file_root = project_config.get("file_root", "")
+    use_saxon_xslt = project_config.get("use_saxon_xslt", False)
+    relative_xsl_path = XSL_PATH_MAP_FOR_JSON_TRANSFORMATIONS.get("publication_metadata")
+
+    xsl_path = safe_join(file_root, relative_xsl_path) if relative_xsl_path else None
+
+    # If the Saxon XSLT processor is not enabled/availabe or XSLT for pulling
+    # additional data from the XML-files and transforming the JSON response
+    # is not available, respond with just the metadata from the database.
+    if (
+        not xsl_path or
+        os.path.isfile(xsl_path) is False or
+        not use_saxon_xslt or
+        not saxon_proc
+    ):
+        return db_metadata, 200
+
+    xml_path_fields = ["publication_filepath", "original_filename"]
+
+    try:
+        db_metadata_with_uris = enrich_db_metadata_with_uris(
+            db_metadata=db_metadata,
+            file_root=file_root,
+            xml_path_fields=xml_path_fields,
+        )
+    except Exception:
+        logger.exception("Unexpected error converting XML file paths to URIs while getting publication metadata.")
+        return {"error": "Unexpected error getting publication metadata."}, 500
+
+    try:
+        # Initialise a SaxonXMLDocument instance
+        saxon_doc: SaxonXMLDocument = SaxonXMLDocument(saxon_proc,
+                                                    xslt30_proc=saxon_xslt_proc)
+
+        # Compile the XSLT into a Saxon XSLT executable
+        saxon_doc.compile_stylesheet(xsl_path)
+
+        # Invoke a transformation by calling the initial-template of the XSLT
+        # stylesheet. The stylesheet reads the database metadata from the
+        # stringified JSON passed as a parameter, reads data from XML-files
+        # declared in the parameters, and returns the final metadata as stringified
+        # JSON. This way the XSLT stylesheet has the final control over which
+        # metadata fields are returned and in which form.
+        json_text_metadata = saxon_doc.call_template_returning_string(
+            parameters=json.dumps(db_metadata_with_uris)
+        )
+    except Exception:
+        logger.exception("Unexpected error invoking a transformation while getting publication metadata.")
+        return {"error": "Unexpected error getting publication metadata."}, 500
+
+    # Validate the stringified JSON by parsing it
+    try:
+        json_metadata = json.loads(json_text_metadata)
+    except json.JSONDecodeError:
+        logger.exception("Invalid JSON from XSLT while getting publication metadata.")
+        return {"error": "Unexpected error getting publication metadata: metadata transform produced invalid JSON."}, 500
+
+    return json_metadata, 200
+
+
 def update_publication_related_table(
         connection: Connection,
         text_type: str,
@@ -1668,3 +1741,103 @@ def ensure_trailing_newline(text: str) -> str:
 
     # Otherwise, default to LF
     return text + "\n"
+
+
+def to_file_uri(file_root: Union[str, Path], rel_path: Optional[str]) -> Optional[str]:
+    """
+    Convert a database-relative file path into an absolute ``file://`` URI.
+
+    The relative path is joined to the configured project file root using
+    :func:`werkzeug.security.safe_join` so the final path remains within the
+    trusted root directory. The resulting filesystem path is then resolved to
+    an absolute path and converted to a ``file://`` URI suitable for XSLT/XPath
+    functions such as ``fn:doc()``.
+
+    Args:
+        file_root: Absolute root directory under which project files are stored.
+            May be given as a string or :class:`pathlib.Path`.
+        rel_path: Relative file path from the database. If ``None`` or an empty
+            string, the function returns ``None``.
+
+    Returns:
+        An absolute file URI such as
+        ``file:///srv/project/documents/publications/text1.xml``, or ``None``
+        if ``rel_path`` is ``None`` or empty.
+
+    Raises:
+        ValueError: If ``rel_path`` is unsafe or resolves outside ``file_root``.
+    """
+    if not rel_path:
+        return None
+
+    abs_path = safe_join(str(file_root), rel_path)
+    if abs_path is None:
+        raise ValueError("Unsafe path outside file root: {!r}".format(rel_path))
+
+    return Path(abs_path).resolve().as_uri()
+
+
+def enrich_db_metadata_with_uris(
+    db_metadata: Mapping[str, Any],
+    file_root: Union[str, Path],
+    xml_path_fields: Iterable[str],
+) -> Dict[str, Any]:
+    """
+    Return a deep-copied metadata structure with ``*_uri`` fields added.
+
+    This function recursively traverses a metadata structure composed of nested
+    dictionaries and lists. Whenever it encounters a dictionary key whose name
+    appears in ``xml_path_fields``, it preserves the original value and adds a
+    sibling key named ``<field>_uri`` whose value is the absolute ``file://``
+    URI derived from that relative path.
+
+    Only string values are converted. Nested dictionaries and lists are
+    processed recursively so XML path fields are handled no matter where they
+    occur within the metadata structure.
+
+    Args:
+        db_metadata: Metadata loaded from the database. This may be a nested
+            structure containing dictionaries and lists.
+        file_root: Absolute root directory under which project files are stored.
+            May be given as a string or :class:`pathlib.Path`.
+        xml_path_fields: Field names whose values should be interpreted as
+            database-relative XML file paths and expanded with corresponding
+            ``*_uri`` keys.
+
+    Returns:
+        A new dictionary containing the same metadata as ``db_metadata`` plus
+        derived ``*_uri`` fields for matching XML path entries found anywhere
+        in the nested structure.
+
+    Raises:
+        ValueError: If any matching XML path is unsafe or resolves outside
+            ``file_root``.
+        TypeError: If ``db_metadata`` is not a mapping at the top level.
+    """
+    if not isinstance(db_metadata, Mapping):
+        raise TypeError("db_metadata must be a mapping")
+
+    xml_path_field_set = set(xml_path_fields)
+
+    def transform(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            result = {}
+
+            for key, item in value.items():
+                result[key] = transform(item)
+
+                if key in xml_path_field_set and isinstance(item, str) and item:
+                    result["{}_uri".format(key)] = to_file_uri(file_root, item)
+
+            return result
+
+        if isinstance(value, list):
+            return [transform(item) for item in value]
+
+        return value
+
+    transformed = transform(db_metadata)
+    if not isinstance(transformed, dict):
+        raise TypeError("Expected transformed top-level metadata to be a dict")
+
+    return transformed

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -1015,8 +1015,9 @@ def construct_publication_metadata_response(
         # declared in the parameters, and returns the final metadata as stringified
         # JSON. This way the XSLT stylesheet has the final control over which
         # metadata fields are returned and in which form.
-        json_text_metadata = saxon_doc.call_template_returning_string(
-            parameters=json.dumps(db_metadata_with_uris)
+        metadata_json = json.dumps(db_metadata_with_uris, ensure_ascii=False)
+        transformed_metadata_json_text = saxon_doc.call_template_returning_string(
+            parameters={"db-json": metadata_json}
         )
     except Exception:
         logger.exception("Unexpected error invoking a transformation while getting publication metadata.")
@@ -1024,12 +1025,12 @@ def construct_publication_metadata_response(
 
     # Validate the stringified JSON by parsing it
     try:
-        json_metadata = json.loads(json_text_metadata)
+        transformed_metadata_json = json.loads(transformed_metadata_json_text)
     except json.JSONDecodeError:
         logger.exception("Invalid JSON from XSLT while getting publication metadata.")
         return {"error": "Unexpected error getting publication metadata: metadata transform produced invalid JSON."}, 500
 
-    return json_metadata, 200
+    return transformed_metadata_json, 200
 
 
 def update_publication_related_table(

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -1129,12 +1129,13 @@ def get_publication_metadata_from_db(
     if not can_show:
         return None, message, 403
 
-    manuscript_published_status = (
+    show_published_status = (
         1 if project_config.get("show_internally_published", False) else 2
     )
 
     try:
         manuscript_table = get_table("publication_manuscript")
+        variant_table = get_table("publication_version")
         facsimile_table = get_table("publication_facsimile")
         facsimile_collection_table = get_table(
             "publication_facsimile_collection"
@@ -1144,16 +1145,16 @@ def get_publication_metadata_from_db(
             manuscript_statement = (
                 select(
                     manuscript_table.c.id,
-                    manuscript_table.c.name,
+                    manuscript_table.c.name.label("title"),
                     manuscript_table.c.original_filename,
+                    manuscript_table.c.section_id,
                     manuscript_table.c.sort_order,
                     manuscript_table.c.language,
-                    manuscript_table.c.published,
                 )
                 .where(manuscript_table.c.publication_id == publication_id)
                 .where(manuscript_table.c.deleted < 1)
                 .where(
-                    manuscript_table.c.published >= manuscript_published_status
+                    manuscript_table.c.published >= show_published_status
                 )
                 .order_by(
                     manuscript_table.c.sort_order,
@@ -1167,15 +1168,49 @@ def get_publication_metadata_from_db(
                 ).mappings().all()
             ]
 
+            variant_statement = (
+                select(
+                    variant_table.c.id,
+                    variant_table.c.name.label("title"),
+                    variant_table.c.original_filename,
+                    variant_table.c.section_id,
+                    variant_table.c.sort_order,
+                    variant_table.c.type,
+                )
+                .where(variant_table.c.publication_id == publication_id)
+                .where(variant_table.c.deleted < 1)
+                .where(
+                    variant_table.c.published >= show_published_status
+                )
+                .order_by(
+                    variant_table.c.sort_order,
+                    variant_table.c.type
+                )
+            )
+            variants = [
+                dict(variant)
+                for variant in connection.execute(
+                    variant_statement
+                ).mappings().all()
+            ]
+
             facsimile_statement = (
                 select(
                     facsimile_table.c.id,
-                    facsimile_table.c.publication_facsimile_collection_id,
+                    facsimile_table.c.publication_facsimile_collection_id.label(
+                        "facs_coll_id"
+                    ),
                     facsimile_table.c.publication_manuscript_id,
+                    facsimile_table.c.publication_version_id.label(
+                        "publication_variant_id"
+                    ),
                     facsimile_table.c.page_nr,
                     facsimile_table.c.priority,
+                    facsimile_table.c.section_id,
                     facsimile_collection_table.c.title,
-                    facsimile_collection_table.c.number_of_pages,
+                    facsimile_collection_table.c.number_of_pages.label(
+                        "number_of_images"
+                    ),
                     facsimile_collection_table.c.description,
                     facsimile_collection_table.c.external_url,
                 )
@@ -1219,8 +1254,9 @@ def get_publication_metadata_from_db(
         "publication_genre": base_row["publication_genre"],
         "publication_date": base_row["publication_date"],
         "publication_language": base_row["publication_language"],
+        "facsimiles": facsimiles,
         "manuscripts": manuscripts,
-        "facsimiles": facsimiles
+        "variants": variants
     }, "", 200
 
 

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -1286,17 +1286,18 @@ def construct_publication_metadata_response(
         project_config: Mapping,
         saxon_processor: Optional[PySaxonProcessor] = None,
         xslt_processor: Optional[PyXslt30Processor] = None,
-        xslt_exec: Optional[PyXsltExecutable] = None
+        xslt_exec: Optional[PyXsltExecutable] = None,
+        use_xslt_transformation: bool = True
 ) -> Tuple[Dict[str, Any], int]:
     """
     Build the final publication metadata response object.
 
     The endpoint first collects publication metadata from the database and
-    passes it to this helper. If Saxon XSLT support is enabled for the project
-    and the project-specific `publication-metadata.xsl` stylesheet exists, the
-    helper enriches XML path fields with internal file URIs and passes the
-    metadata JSON to the stylesheet. The stylesheet can then read additional
-    metadata from XML files and return the final response object as JSON.
+    passes it to this helper. If Saxon is available and the project-specific
+    `publication-metadata.xsl` stylesheet exists, the helper enriches XML path
+    fields with internal file URIs and passes the metadata JSON to the
+    stylesheet. The stylesheet can then read additional metadata from XML files
+    and return the final response object as JSON.
 
     If Saxon support or the stylesheet is unavailable, the database metadata is
     returned directly. In both paths, internal file path fields and generated
@@ -1306,18 +1307,22 @@ def construct_publication_metadata_response(
         db_metadata: Metadata collected from the database. May contain nested
             dictionaries and lists, including internal XML file path fields.
         project_config: Project configuration mapping. Uses `file_root`,
-            `use_saxon_xslt`, and the project XSLT location.
+            from which the project XSLT location is resolved.
         saxon_processor: Optional Saxon processor to use for the XSLT
             transformation. If not passed, the module-level `saxon_proc`
             processor is used.
         xslt_processor: Optional Saxon XSLT 3.0 processor to use when compiling
-            the stylesheet. If not passed, the module-level `saxon_xslt_proc`
-            processor is used. When supplied, it must have been created from
-            the same Saxon processor instance that this function uses.
+            the stylesheet. If neither `saxon_processor` nor `xslt_processor`
+            is passed, the module-level `saxon_xslt_proc` processor is used.
+            When supplied, it must have been created from the same Saxon
+            processor instance that this function uses.
         xslt_exec: Optional precompiled Saxon XSLT executable. When supplied,
             the stylesheet is not compiled inside this function. The executable
             must be compatible with the Saxon processor used for the
             transformation.
+        use_xslt_transformation: Whether to attempt metadata enrichment with
+            `publication-metadata.xsl`. If False, the sanitized database
+            metadata is returned directly.
 
     Returns:
         A tuple of `(response_data, status_code)`. On success,
@@ -1326,18 +1331,19 @@ def construct_publication_metadata_response(
         error message and status is 500.
     """
     file_root = project_config.get("file_root", "")
-    use_saxon_xslt = project_config.get("use_saxon_xslt", False)
     relative_xsl_path = XSL_PATH_MAP_FOR_JSON_TRANSFORMATIONS.get("publication_metadata")
     xml_path_fields = ["publication_filepath", "original_filename"]
-    saxon_processor = saxon_processor or saxon_proc
-    xslt_processor = xslt_processor or saxon_xslt_proc
+    if saxon_processor is None:
+        saxon_processor = saxon_proc
+        if xslt_processor is None:
+            xslt_processor = saxon_xslt_proc
 
     xsl_path = safe_join(file_root, relative_xsl_path) if relative_xsl_path else None
 
-    # If the Saxon XSLT processor is not enabled/available or XSLT for pulling
-    # additional data from the XML-files and transforming the JSON response
-    # is not available, respond with just the metadata from the database.
+    # If Saxon, the metadata stylesheet, or XSLT enrichment is not available,
+    # respond with just the metadata from the database.
     if (
+        not use_xslt_transformation or
         (
             xslt_exec is None and
             (
@@ -1345,7 +1351,6 @@ def construct_publication_metadata_response(
                 os.path.isfile(xsl_path) is False
             )
         ) or
-        not use_saxon_xslt or
         not saxon_processor
     ):
         return remove_file_path_fields(db_metadata, xml_path_fields), 200

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -548,7 +548,7 @@ def can_show_published_values(
         return False, "Content is not publicly available."
 
 
-def get_show_published_status(project_config: Mapping) -> int:
+def resolve_project_published_threshold(project_config: Mapping) -> int:
     """
     Return the lowest published status visible for a project.
 
@@ -588,8 +588,8 @@ def get_published_status(
     published (published==2), or if they're internally published
     (published==1) and show_internally_published is True
 
-    TODO: Change this to use ``get_show_published_status(project_config)``
-    so ``show_unpublished`` is handled consistently with newer endpoints.
+    TODO: Change this to use ``resolve_project_published_threshold(project_config)``
+    so ``show_unpublished`` in config is handled consistently.
     """
     project_config = get_project_config(project)
     if project_config is None:
@@ -650,6 +650,10 @@ def get_published_status(
         logger.exception(message)
         return False, message, None
 
+    # TODO: Change this to use `resolve_project_published_threshold(project_config)`
+    # so `show_unpublished` in config is also respected. This might alter behaviour
+    # for projects that have `show_unpublished: True` and `show_internally_published: False`
+    # in the project config. Check if there are such projects before making this change.
     show_published_status = (
         1 if project_config["show_internally_published"] else 2
     )
@@ -1033,7 +1037,7 @@ def get_publication_metadata_base_row(
 
     The row includes the published status values needed for visibility checks.
     """
-    show_published_status = get_show_published_status(project_config)
+    show_published_status = resolve_project_published_threshold(project_config)
 
     try:
         project_table = get_table("project")
@@ -1131,7 +1135,7 @@ def can_show_publication_metadata_row(
             row["collection_published"],
             row["publication_published"]
         ],
-        get_show_published_status(project_config)
+        resolve_project_published_threshold(project_config)
     )
 
 
@@ -1166,7 +1170,7 @@ def get_publication_metadata_from_db(
     if not can_show:
         return None, message, 403
 
-    show_published_status = get_show_published_status(project_config)
+    show_published_status = resolve_project_published_threshold(project_config)
 
     try:
         manuscript_table = get_table("publication_manuscript")

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -1004,7 +1004,7 @@ def construct_publication_metadata_response(
     try:
         # Initialise a SaxonXMLDocument instance
         saxon_doc: SaxonXMLDocument = SaxonXMLDocument(saxon_proc,
-                                                    xslt30_proc=saxon_xslt_proc)
+                                                       xslt30_proc=saxon_xslt_proc)
 
         # Compile the XSLT into a Saxon XSLT executable
         saxon_doc.compile_stylesheet(xsl_path)

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -16,7 +16,7 @@ import re
 from ruamel.yaml import YAML
 from saxonche import PySaxonProcessor, PyXslt30Processor, PyXsltExecutable
 from sls_api.models import User
-from sqlalchemy import create_engine, Connection, MetaData, RowMapping, Table
+from sqlalchemy import create_engine, Connection, func, MetaData, RowMapping, Table
 from sqlalchemy.sql import and_, select, text
 from sqlalchemy.sql.selectable import Select
 import time
@@ -48,6 +48,12 @@ DEFAULT_COLLATION = "sv-x-icu"  # Generic Swedish Unicode collation
 # in the "xml" folder. Hence "html/documents" (we might also have other
 # HTML than prerendered HTML from the XML files).
 PRERENDERED_HTML_PATH_IN_PROJECT_ROOT = "html/documents"
+
+# Folder paths from the project root to folders where prerendered JSON
+# output is located.
+PRERENDERED_JSON_PATH_MAP_IN_PROJECT_ROOT = {
+    "publication_metadata": "json/publication-metadata"
+}
 
 # Map of paths to XSLT stylesheets for XML->HTML transformations for
 # different text types. The paths to the XSLT stylesheets are relative
@@ -968,9 +974,319 @@ def get_frontmatter_page_content(
     )
 
 
+def get_project_frontend_languages(project_config: Mapping) -> List[str]:
+    """
+    Return valid frontend language codes configured for a project.
+
+    Projects can configure ``frontend_languages`` as an array of language
+    codes. If the setting is missing, malformed, empty, or contains no valid
+    language codes, Swedish is used as the default.
+    """
+    languages = project_config.get("frontend_languages", ["sv"])
+    if isinstance(languages, str):
+        languages = [languages]
+    if not isinstance(languages, list):
+        return ["sv"]
+
+    valid_languages = []
+    for language in languages:
+        if (
+            isinstance(language, str) and
+            is_valid_language(language) and
+            language not in valid_languages
+        ):
+            valid_languages.append(language)
+
+    return valid_languages or ["sv"]
+
+
+def get_publication_metadata_base_row(
+        project: str,
+        publication_id: int,
+        language: str
+) -> Tuple[Optional[RowMapping], str, int]:
+    """
+    Fetch the publication and collection row used by publication metadata.
+
+    The row includes the published status values needed for visibility checks.
+    """
+    try:
+        project_table = get_table("project")
+        collection_table = get_table("publication_collection")
+        publication_table = get_table("publication")
+        translation_text_table = get_table("translation_text")
+
+        with db_engine.connect() as connection:
+            statement = (
+                select(
+                    project_table.c.published.label("project_published"),
+                    collection_table.c.id.label("collection_id"),
+                    func.coalesce(
+                        translation_text_table.c.text,
+                        collection_table.c.name
+                    ).label("collection_title"),
+                    collection_table.c.published.label("collection_published"),
+                    publication_table.c.name.label("publication_title"),
+                    publication_table.c.original_filename.label(
+                        "publication_filepath"
+                    ),
+                    publication_table.c.published.label("publication_published"),
+                    publication_table.c.genre.label("publication_genre"),
+                    publication_table.c.original_publication_date.label(
+                        "publication_date"
+                    ),
+                    publication_table.c.language.label("publication_language"),
+                )
+                .select_from(
+                    project_table
+                    .join(
+                        collection_table,
+                        collection_table.c.project_id == project_table.c.id,
+                    )
+                    .join(
+                        publication_table,
+                        publication_table.c.publication_collection_id == (
+                            collection_table.c.id
+                        )
+                    )
+                    .outerjoin(
+                        translation_text_table,
+                        and_(
+                            collection_table.c.name_translation_id == (
+                                translation_text_table.c.translation_id
+                            ),
+                            translation_text_table.c.language == language,
+                            translation_text_table.c.deleted < 1
+                        )
+                    )
+                )
+                .where(project_table.c.name == str(project))
+                .where(publication_table.c.id == publication_id)
+                .where(project_table.c.deleted < 1)
+                .where(collection_table.c.deleted < 1)
+                .where(publication_table.c.deleted < 1)
+            )
+            row = connection.execute(statement).mappings().first()
+    except Exception:
+        logger.exception(
+            "Unexpected error getting publication metadata for %s/%s",
+            project,
+            publication_id
+        )
+        return None, "Unexpected error getting publication metadata.", 500
+
+    if row is None:
+        return None, "Content does not exist.", 404
+
+    return row, "", 200
+
+
+def can_show_publication_metadata_row(
+        row: RowMapping,
+        project_config: Mapping
+) -> Tuple[bool, str]:
+    """
+    Return whether the publication metadata row passes visibility checks.
+    """
+    show_internal = project_config.get("show_internally_published", False)
+    return can_show_published_values(
+        [
+            row["project_published"],
+            row["collection_published"],
+            row["publication_published"]
+        ],
+        show_internal
+    )
+
+
+def get_publication_metadata_from_db(
+        project: str,
+        publication_id: int,
+        language: str,
+        project_config: Mapping,
+        base_row: Optional[RowMapping] = None
+) -> Tuple[Optional[Dict[str, Any]], str, int]:
+    """
+    Build the database metadata object for a publication metadata response.
+
+    The returned data may still contain internal XML path fields. Callers
+    should pass it through ``construct_publication_metadata_response`` before
+    returning it publicly.
+    """
+    if base_row is None:
+        base_row, message, status_code = get_publication_metadata_base_row(
+            project,
+            publication_id,
+            language
+        )
+        if base_row is None:
+            return None, message, status_code
+
+    can_show, message = can_show_publication_metadata_row(
+        base_row,
+        project_config
+    )
+    if not can_show:
+        return None, message, 403
+
+    manuscript_published_status = (
+        1 if project_config.get("show_internally_published", False) else 2
+    )
+
+    try:
+        manuscript_table = get_table("publication_manuscript")
+        facsimile_table = get_table("publication_facsimile")
+        facsimile_collection_table = get_table(
+            "publication_facsimile_collection"
+        )
+
+        with db_engine.connect() as connection:
+            manuscript_statement = (
+                select(
+                    manuscript_table.c.id,
+                    manuscript_table.c.name,
+                    manuscript_table.c.original_filename,
+                    manuscript_table.c.sort_order,
+                    manuscript_table.c.language,
+                    manuscript_table.c.published,
+                )
+                .where(manuscript_table.c.publication_id == publication_id)
+                .where(manuscript_table.c.deleted < 1)
+                .where(
+                    manuscript_table.c.published >= manuscript_published_status
+                )
+                .order_by(
+                    manuscript_table.c.sort_order,
+                    manuscript_table.c.name
+                )
+            )
+            manuscripts = [
+                dict(manuscript)
+                for manuscript in connection.execute(
+                    manuscript_statement
+                ).mappings().all()
+            ]
+
+            facsimile_statement = (
+                select(
+                    facsimile_table.c.id,
+                    facsimile_table.c.publication_facsimile_collection_id,
+                    facsimile_table.c.publication_manuscript_id,
+                    facsimile_table.c.page_nr,
+                    facsimile_table.c.priority,
+                    facsimile_collection_table.c.title,
+                    facsimile_collection_table.c.number_of_pages,
+                    facsimile_collection_table.c.description,
+                    facsimile_collection_table.c.external_url,
+                )
+                .select_from(
+                    facsimile_table.join(
+                        facsimile_collection_table,
+                        facsimile_table.c.publication_facsimile_collection_id == (
+                            facsimile_collection_table.c.id
+                        )
+                    )
+                )
+                .where(facsimile_table.c.publication_id == publication_id)
+                .where(facsimile_table.c.deleted < 1)
+                .where(facsimile_collection_table.c.deleted < 1)
+                .order_by(
+                    facsimile_table.c.priority,
+                    facsimile_table.c.id
+                )
+            )
+            facsimiles = [
+                dict(facsimile)
+                for facsimile in connection.execute(
+                    facsimile_statement
+                ).mappings().all()
+            ]
+    except Exception:
+        logger.exception(
+            "Unexpected error getting publication metadata details for %s/%s",
+            project,
+            publication_id
+        )
+        return None, "Unexpected error getting publication metadata.", 500
+
+    return {
+        "metadata_language": language,
+        "publication_id": publication_id,
+        "collection_id": base_row["collection_id"],
+        "collection_title": base_row["collection_title"],
+        "publication_title": base_row["publication_title"],
+        "publication_filepath": base_row["publication_filepath"],
+        "publication_genre": base_row["publication_genre"],
+        "publication_date": base_row["publication_date"],
+        "publication_language": base_row["publication_language"],
+        "manuscripts": manuscripts,
+        "facsimiles": facsimiles
+    }, "", 200
+
+
+def get_prerendered_json_content(
+        project_file_root: str,
+        json_type: str,
+        json_filename: str
+) -> Optional[Dict[str, Any]]:
+    """
+    Return parsed prerendered JSON content, or ``None`` if unavailable.
+    """
+    json_dir = PRERENDERED_JSON_PATH_MAP_IN_PROJECT_ROOT.get(json_type)
+    if json_dir is None:
+        logger.error("No prerendered JSON folder configured for %s", json_type)
+        return None
+
+    file_path = safe_join(project_file_root, json_dir, json_filename)
+    if file_path is None:
+        logger.error("safe_join returned None for JSON path %r", json_filename)
+        return None
+
+    if not os.path.isfile(file_path):
+        return None
+
+    try:
+        with open(file_path, "r", encoding="utf-8") as json_file:
+            content = json.load(json_file)
+    except json.JSONDecodeError:
+        logger.exception("Invalid prerendered JSON in %s", file_path)
+        return None
+    except OSError as e:
+        logger.exception("OS error reading %s: %s", file_path, e)
+        return None
+    except Exception:
+        logger.exception("Unexpected error when reading %s", file_path)
+        return None
+
+    if not isinstance(content, dict):
+        logger.error("Prerendered JSON in %s is not an object.", file_path)
+        return None
+
+    return content
+
+
+def get_prerendered_publication_metadata_content(
+        project_file_root: str,
+        publication_id: int,
+        language: str
+) -> Optional[Dict[str, Any]]:
+    """
+    Return prerendered publication metadata for one publication and language.
+    """
+    json_filename = f"{publication_id}_{language}_metadata.json"
+    return get_prerendered_json_content(
+        project_file_root,
+        "publication_metadata",
+        json_filename
+    )
+
+
 def construct_publication_metadata_response(
         db_metadata: Dict[str, Any],
-        project_config: Mapping
+        project_config: Mapping,
+        saxon_processor: Optional[PySaxonProcessor] = None,
+        xslt_processor: Optional[PyXslt30Processor] = None,
+        xslt_exec: Optional[PyXsltExecutable] = None
 ) -> Tuple[Dict[str, Any], int]:
     """
     Build the final publication metadata response object.
@@ -991,6 +1307,17 @@ def construct_publication_metadata_response(
             dictionaries and lists, including internal XML file path fields.
         project_config: Project configuration mapping. Uses `file_root`,
             `use_saxon_xslt`, and the project XSLT location.
+        saxon_processor: Optional Saxon processor to use for the XSLT
+            transformation. If not passed, the module-level `saxon_proc`
+            processor is used.
+        xslt_processor: Optional Saxon XSLT 3.0 processor to use when compiling
+            the stylesheet. If not passed, the module-level `saxon_xslt_proc`
+            processor is used. When supplied, it must have been created from
+            the same Saxon processor instance that this function uses.
+        xslt_exec: Optional precompiled Saxon XSLT executable. When supplied,
+            the stylesheet is not compiled inside this function. The executable
+            must be compatible with the Saxon processor used for the
+            transformation.
 
     Returns:
         A tuple of `(response_data, status_code)`. On success,
@@ -1002,17 +1329,24 @@ def construct_publication_metadata_response(
     use_saxon_xslt = project_config.get("use_saxon_xslt", False)
     relative_xsl_path = XSL_PATH_MAP_FOR_JSON_TRANSFORMATIONS.get("publication_metadata")
     xml_path_fields = ["publication_filepath", "original_filename"]
+    saxon_processor = saxon_processor or saxon_proc
+    xslt_processor = xslt_processor or saxon_xslt_proc
 
     xsl_path = safe_join(file_root, relative_xsl_path) if relative_xsl_path else None
 
-    # If the Saxon XSLT processor is not enabled/availabe or XSLT for pulling
+    # If the Saxon XSLT processor is not enabled/available or XSLT for pulling
     # additional data from the XML-files and transforming the JSON response
     # is not available, respond with just the metadata from the database.
     if (
-        not xsl_path or
-        os.path.isfile(xsl_path) is False or
+        (
+            xslt_exec is None and
+            (
+                not xsl_path or
+                os.path.isfile(xsl_path) is False
+            )
+        ) or
         not use_saxon_xslt or
-        not saxon_proc
+        not saxon_processor
     ):
         return remove_file_path_fields(db_metadata, xml_path_fields), 200
 
@@ -1028,11 +1362,15 @@ def construct_publication_metadata_response(
 
     try:
         # Initialise a SaxonXMLDocument instance
-        saxon_doc: SaxonXMLDocument = SaxonXMLDocument(saxon_proc,
-                                                       xslt30_proc=saxon_xslt_proc)
+        saxon_doc: SaxonXMLDocument = SaxonXMLDocument(
+            saxon_processor,
+            xslt30_proc=xslt_processor
+        )
 
-        # Compile the XSLT into a Saxon XSLT executable
-        saxon_doc.compile_stylesheet(xsl_path)
+        # Compile the XSLT into a Saxon XSLT executable if the caller
+        # did not provide a precompiled executable.
+        if xslt_exec is None:
+            xslt_exec = saxon_doc.compile_stylesheet(xsl_path)
 
         # Invoke a transformation by calling the initial-template of the XSLT
         # stylesheet. The stylesheet reads the database metadata from the
@@ -1040,9 +1378,10 @@ def construct_publication_metadata_response(
         # declared in the parameters, and returns the final metadata as stringified
         # JSON. This way the XSLT stylesheet has the final control over which
         # metadata fields are returned and in which form.
-        db_metadata_json = json.dumps(db_metadata_with_uris, ensure_ascii=False)
+        db_metadata_json_text = json.dumps(db_metadata_with_uris, ensure_ascii=False)
         transformed_metadata_json_text = saxon_doc.call_template_returning_string(
-            parameters={"db-json": db_metadata_json}
+            xslt_exec=xslt_exec,
+            parameters={"db-json": db_metadata_json_text}
         )
     except Exception:
         logger.exception("Unexpected error invoking a transformation while getting publication metadata.")

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -972,9 +972,36 @@ def construct_publication_metadata_response(
         db_metadata: Dict[str, Any],
         project_config: Mapping
 ) -> Tuple[Dict[str, Any], int]:
+    """
+    Build the final publication metadata response object.
+
+    The endpoint first collects publication metadata from the database and
+    passes it to this helper. If Saxon XSLT support is enabled for the project
+    and the project-specific `publication-metadata.xsl` stylesheet exists, the
+    helper enriches XML path fields with internal file URIs and passes the
+    metadata JSON to the stylesheet. The stylesheet can then read additional
+    metadata from XML files and return the final response object as JSON.
+
+    If Saxon support or the stylesheet is unavailable, the database metadata is
+    returned directly. In both paths, internal file path fields and generated
+    `*_uri` fields are removed before the response is returned.
+
+    Args:
+        db_metadata: Metadata collected from the database. May contain nested
+            dictionaries and lists, including internal XML file path fields.
+        project_config: Project configuration mapping. Uses `file_root`,
+            `use_saxon_xslt`, and the project XSLT location.
+
+    Returns:
+        A tuple of `(response_data, status_code)`. On success,
+        `response_data` is the sanitized metadata response and status is 200.
+        On transformation or JSON parsing failure, `response_data` contains an
+        error message and status is 500.
+    """
     file_root = project_config.get("file_root", "")
     use_saxon_xslt = project_config.get("use_saxon_xslt", False)
     relative_xsl_path = XSL_PATH_MAP_FOR_JSON_TRANSFORMATIONS.get("publication_metadata")
+    xml_path_fields = ["publication_filepath", "original_filename"]
 
     xsl_path = safe_join(file_root, relative_xsl_path) if relative_xsl_path else None
 
@@ -987,9 +1014,7 @@ def construct_publication_metadata_response(
         not use_saxon_xslt or
         not saxon_proc
     ):
-        return db_metadata, 200
-
-    xml_path_fields = ["publication_filepath", "original_filename"]
+        return remove_file_path_fields(db_metadata, xml_path_fields), 200
 
     try:
         db_metadata_with_uris = enrich_db_metadata_with_uris(
@@ -1015,9 +1040,9 @@ def construct_publication_metadata_response(
         # declared in the parameters, and returns the final metadata as stringified
         # JSON. This way the XSLT stylesheet has the final control over which
         # metadata fields are returned and in which form.
-        metadata_json = json.dumps(db_metadata_with_uris, ensure_ascii=False)
+        db_metadata_json = json.dumps(db_metadata_with_uris, ensure_ascii=False)
         transformed_metadata_json_text = saxon_doc.call_template_returning_string(
-            parameters={"db-json": metadata_json}
+            parameters={"db-json": db_metadata_json}
         )
     except Exception:
         logger.exception("Unexpected error invoking a transformation while getting publication metadata.")
@@ -1030,7 +1055,7 @@ def construct_publication_metadata_response(
         logger.exception("Invalid JSON from XSLT while getting publication metadata.")
         return {"error": "Unexpected error getting publication metadata: metadata transform produced invalid JSON."}, 500
 
-    return transformed_metadata_json, 200
+    return remove_file_path_fields(transformed_metadata_json, xml_path_fields), 200
 
 
 def update_publication_related_table(
@@ -1838,6 +1863,59 @@ def enrich_db_metadata_with_uris(
         return value
 
     transformed = transform(db_metadata)
+    if not isinstance(transformed, dict):
+        raise TypeError("Expected transformed top-level metadata to be a dict")
+
+    return transformed
+
+
+def remove_file_path_fields(
+    metadata: Mapping[str, Any],
+    xml_path_fields: Iterable[str],
+) -> Dict[str, Any]:
+    """
+    Return a deep-copied metadata structure with private file path fields
+    removed.
+
+    The publication metadata XSLT receives internal file paths and generated
+    file URIs so it can read XML files with Saxon. Those paths should not be
+    exposed in the public API response. This helper recursively removes keys
+    listed in ``xml_path_fields`` and any generated ``*_uri`` keys from nested
+    dictionaries and lists.
+
+    Args:
+        metadata: Metadata response object.
+        xml_path_fields: Field names containing database-relative file paths.
+
+    Returns:
+        A new dictionary without internal file path or file URI fields.
+
+    Raises:
+        TypeError: If ``metadata`` is not a mapping at the top level.
+    """
+    if not isinstance(metadata, Mapping):
+        raise TypeError("metadata must be a mapping")
+
+    xml_path_field_set = set(xml_path_fields)
+
+    def transform(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            result = {}
+
+            for key, item in value.items():
+                if key in xml_path_field_set or str(key).endswith("_uri"):
+                    continue
+
+                result[key] = transform(item)
+
+            return result
+
+        if isinstance(value, list):
+            return [transform(item) for item in value]
+
+        return value
+
+    transformed = transform(metadata)
     if not isinstance(transformed, dict):
         raise TypeError("Expected transformed top-level metadata to be a dict")
 

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -1247,13 +1247,13 @@ def get_publication_metadata_from_db(
     return {
         "metadata_language": language,
         "publication_id": publication_id,
-        "collection_id": base_row["collection_id"],
-        "collection_title": base_row["collection_title"],
         "publication_title": base_row["publication_title"],
         "publication_filepath": base_row["publication_filepath"],
         "publication_genre": base_row["publication_genre"],
         "publication_date": base_row["publication_date"],
         "publication_language": base_row["publication_language"],
+        "collection_id": base_row["collection_id"],
+        "collection_title": base_row["collection_title"],
         "facsimiles": facsimiles,
         "manuscripts": manuscripts,
         "variants": variants

--- a/sls_api/endpoints/generics.py
+++ b/sls_api/endpoints/generics.py
@@ -654,7 +654,7 @@ def get_published_status(
     # so `show_unpublished` in config is also respected. This might alter behaviour
     # for projects that have `show_unpublished: True` and `show_internally_published: False`
     # in the project config. Check if there are such projects before making this change.
-    show_published_status = (
+    show_published_threshold = (
         1 if project_config["show_internally_published"] else 2
     )
     can_show = False
@@ -671,7 +671,7 @@ def get_published_status(
 
         can_show, message = can_show_published_values(
             pub_values,
-            show_published_status
+            show_published_threshold
         )
 
     return can_show, message, col_legacy_id

--- a/sls_api/endpoints/metadata.py
+++ b/sls_api/endpoints/metadata.py
@@ -9,11 +9,13 @@ import sqlalchemy.sql
 from urllib.parse import unquote
 from werkzeug.security import safe_join
 
-from sls_api.endpoints.generics import can_show_published_values, \
+from sls_api.endpoints.generics import \
+    can_show_publication_metadata_row, construct_publication_metadata_response, \
     db_engine, get_project_config, get_project_id_from_name, path_hierarchy, \
+    get_prerendered_publication_metadata_content, \
+    get_publication_metadata_base_row, get_publication_metadata_from_db, \
     select_all_from_table, flatten_json, get_first_valid_item_from_toc, \
-    int_or_none, get_table, is_valid_language, reader_auth_required, \
-    construct_publication_metadata_response
+    int_or_none, get_table, is_valid_language, reader_auth_required
 
 meta = Blueprint('metadata', __name__, url_prefix="/digitaledition")
 
@@ -751,7 +753,8 @@ def get_publication_metadata(project, publication_id, language='sv'):
     if project_config is None:
         return jsonify({"error": f"The project '{project}' does not exist."}), 400
 
-    if project_config.get("file_root") is None:
+    file_root = project_config.get("file_root")
+    if file_root is None:
         return jsonify({"error": f"File root missing from '{project}' project config."}), 500
 
     p_id = int_or_none(publication_id)
@@ -761,191 +764,47 @@ def get_publication_metadata(project, publication_id, language='sv'):
     if language is not None and not is_valid_language(language):
         return jsonify({"error": "Invalid language."}), 400
 
-    # Get core data of publication and collection from the database
-    try:
-        project_table = get_table("project")
-        collection_table = get_table("publication_collection")
-        publication_table = get_table("publication")
-        translation_text_table = get_table("translation_text")
+    base_row, message, status_code = get_publication_metadata_base_row(
+        project,
+        p_id,
+        language
+    )
+    if base_row is None:
+        return jsonify({"error": message}), status_code
 
-        with db_engine.connect() as connection:
-            statement = (
-                sqlalchemy.sql.select(
-                    project_table.c.published.label("project_published"),
-                    collection_table.c.id.label("collection_id"),
-                    sqlalchemy.sql.func.coalesce(
-                        translation_text_table.c.text,
-                        collection_table.c.name
-                    ).label("collection_title"),
-                    collection_table.c.published.label("collection_published"),
-                    publication_table.c.name.label("publication_title"),
-                    publication_table.c.original_filename.label("publication_filepath"),
-                    publication_table.c.published.label("publication_published"),
-                    publication_table.c.genre.label("publication_genre"),
-                    publication_table.c.original_publication_date.label(
-                        "publication_date"
-                    ),
-                    publication_table.c.language.label("publication_language"),
-                )
-                .select_from(
-                    project_table
-                    .join(
-                        collection_table,
-                        collection_table.c.project_id == project_table.c.id,
-                    )
-                    .join(
-                        publication_table,
-                        publication_table.c.publication_collection_id == collection_table.c.id
-                    )
-                    .outerjoin(
-                        translation_text_table,
-                        sqlalchemy.sql.and_(
-                            collection_table.c.name_translation_id == (
-                                translation_text_table.c.translation_id
-                            ),
-                            translation_text_table.c.language == language,
-                            translation_text_table.c.deleted < 1
-                        )
-                    )
-                )
-                .where(project_table.c.name == str(project))
-                .where(publication_table.c.id == p_id)
-                .where(project_table.c.deleted < 1)
-                .where(collection_table.c.deleted < 1)
-                .where(publication_table.c.deleted < 1)
-            )
-            row = connection.execute(statement).mappings().first()
-    except Exception:
-        logger.exception(
-            "Unexpected error getting publication metadata for %s/%s",
-            project,
-            publication_id
-        )
-        return jsonify({"error": "Unexpected error getting publication metadata."}), 500
-
-    if row is None:
-        return jsonify({"error": "Content does not exist."}), 404
-
-    show_internal = project_config.get("show_internally_published", False)
-    can_show, message = can_show_published_values(
-        [
-            row["project_published"],
-            row["collection_published"],
-            row["publication_published"]
-        ],
-        show_internal
+    can_show, message = can_show_publication_metadata_row(
+        base_row,
+        project_config
     )
     if not can_show:
         return jsonify({"error": message}), 403
 
-    manuscript_published_status = (1 if show_internal else 2)
+    prerender_json = project_config.get("prerender_json", False)
 
-    # Get manuscripts linked to the publication
-    try:
-        manuscript_table = get_table("publication_manuscript")
+    if prerender_json:
+        prerendered_metadata = get_prerendered_publication_metadata_content(
+            file_root,
+            p_id,
+            language
+        )
+        if prerendered_metadata is not None:
+            return jsonify(prerendered_metadata), 200
 
-        with db_engine.connect() as connection:
-            manuscript_statement = (
-                sqlalchemy.sql.select(
-                    manuscript_table.c.id,
-                    manuscript_table.c.name,
-                    manuscript_table.c.original_filename,
-                    manuscript_table.c.sort_order,
-                    manuscript_table.c.language,
-                    manuscript_table.c.published,
-                )
-                .where(manuscript_table.c.publication_id == p_id)
-                .where(manuscript_table.c.deleted < 1)
-                .where(
-                    manuscript_table.c.published >= manuscript_published_status
-                )
-                .order_by(
-                    manuscript_table.c.sort_order,
-                    manuscript_table.c.name
-                )
-            )
-            manuscripts = [
-                dict(manuscript)
-                for manuscript in connection.execute(
-                    manuscript_statement
-                ).mappings().all()
-            ]
-    except Exception:
-        logger.exception(
-            "Unexpected error getting publication manuscripts for %s/%s",
+    db_metadata, message, status_code = get_publication_metadata_from_db(
+        project,
+        p_id,
+        language,
+        project_config,
+        base_row=base_row
+    )
+    if db_metadata is None:
+        logger.error(
+            "Unable to build publication metadata for %s/%s: %s",
             project,
-            publication_id
+            p_id,
+            message
         )
-        return jsonify({
-            "error": "Unexpected error getting publication metadata."
-        }), 500
-
-    # Get facsimiles linked to the publication
-    try:
-        facsimile_table = get_table("publication_facsimile")
-        facsimile_collection_table = get_table(
-            "publication_facsimile_collection"
-        )
-
-        with db_engine.connect() as connection:
-            facsimile_statement = (
-                sqlalchemy.sql.select(
-                    facsimile_table.c.id,
-                    facsimile_table.c.publication_facsimile_collection_id,
-                    facsimile_table.c.publication_manuscript_id,
-                    facsimile_table.c.page_nr,
-                    facsimile_table.c.priority,
-                    facsimile_collection_table.c.title,
-                    facsimile_collection_table.c.number_of_pages,
-                    facsimile_collection_table.c.description,
-                    facsimile_collection_table.c.external_url,
-                )
-                .select_from(
-                    facsimile_table.join(
-                        facsimile_collection_table,
-                        facsimile_table.c.publication_facsimile_collection_id == (
-                            facsimile_collection_table.c.id
-                        )
-                    )
-                )
-                .where(facsimile_table.c.publication_id == p_id)
-                .where(facsimile_table.c.deleted < 1)
-                .where(facsimile_collection_table.c.deleted < 1)
-                .order_by(
-                    facsimile_table.c.priority,
-                    facsimile_table.c.id
-                )
-            )
-            facsimiles = [
-                dict(facsimile)
-                for facsimile in connection.execute(
-                    facsimile_statement
-                ).mappings().all()
-            ]
-    except Exception:
-        logger.exception(
-            "Unexpected error getting publication facsimiles for %s/%s",
-            project,
-            publication_id
-        )
-        return jsonify({
-            "error": "Unexpected error getting publication metadata."
-        }), 500
-
-    # Dictionary with publication metadata from the database
-    db_metadata = {
-        "metadata_language": language,
-        "publication_id": p_id,
-        "collection_id": row["collection_id"],
-        "collection_title": row["collection_title"],
-        "publication_title": row["publication_title"],
-        "publication_filepath": row["publication_filepath"],
-        "publication_genre": row["publication_genre"],
-        "publication_date": row["publication_date"],
-        "publication_language": row["publication_language"],
-        "manuscripts": manuscripts,
-        "facsimiles": facsimiles
-    }
+        return jsonify({"error": message}), status_code
 
     response_data, response_status = construct_publication_metadata_response(
         db_metadata,

--- a/sls_api/endpoints/metadata.py
+++ b/sls_api/endpoints/metadata.py
@@ -763,17 +763,24 @@ def get_publication_metadata(project, publication_id, language='sv'):
         project_table = get_table("project")
         collection_table = get_table("publication_collection")
         publication_table = get_table("publication")
+        translation_text_table = get_table("translation_text")
 
         with db_engine.connect() as connection:
             statement = (
                 sqlalchemy.sql.select(
                     project_table.c.published.label("project_published"),
                     collection_table.c.id.label("collection_id"),
+                    sqlalchemy.sql.func.coalesce(
+                        translation_text_table.c.text,
+                        collection_table.c.name
+                    ).label("collection_title"),
                     collection_table.c.published.label("collection_published"),
                     publication_table.c.name.label("publication_title"),
                     publication_table.c.published.label("publication_published"),
                     publication_table.c.genre.label("publication_genre"),
-                    publication_table.c.original_publication_date.label("publication_date"),
+                    publication_table.c.original_publication_date.label(
+                        "publication_date"
+                    ),
                     publication_table.c.language.label("publication_language"),
                 )
                 .select_from(
@@ -785,6 +792,16 @@ def get_publication_metadata(project, publication_id, language='sv'):
                     .join(
                         publication_table,
                         publication_table.c.publication_collection_id == collection_table.c.id
+                    )
+                    .outerjoin(
+                        translation_text_table,
+                        sqlalchemy.sql.and_(
+                            collection_table.c.name_translation_id == (
+                                translation_text_table.c.translation_id
+                            ),
+                            translation_text_table.c.language == language,
+                            translation_text_table.c.deleted < 1
+                        )
                     )
                 )
                 .where(project_table.c.name == str(project))
@@ -806,7 +823,11 @@ def get_publication_metadata(project, publication_id, language='sv'):
         return jsonify({"error": "Content does not exist."}), 404
 
     can_show, message = can_show_published_values(
-        [row["project_published"], row["collection_published"], row["publication_published"]],
+        [
+            row["project_published"],
+            row["collection_published"],
+            row["publication_published"]
+        ],
         project_config["show_internally_published"]
     )
     if not can_show:
@@ -815,7 +836,11 @@ def get_publication_metadata(project, publication_id, language='sv'):
     return jsonify({
         "id": p_id,
         "collection_id": row["collection_id"],
-        "collection_legacy_id": row["col_legacy_id"]
+        "collection_title": row["collection_title"],
+        "publication_title": row["publication_title"],
+        "publication_genre": row["publication_genre"],
+        "publication_date": row["publication_date"],
+        "publication_language": row["publication_language"]
     }), 200
 
 

--- a/sls_api/endpoints/metadata.py
+++ b/sls_api/endpoints/metadata.py
@@ -746,7 +746,7 @@ def get_urn(project, url, legacy_id=None):
 @reader_auth_required()
 def get_publication_metadata(project, publication_id, language='sv'):
     """
-    Get metadata for a given publication.
+    Get metadata for a given publication in a specific language.
     """
     # Validate parameters
     project_config = get_project_config(project)
@@ -764,6 +764,7 @@ def get_publication_metadata(project, publication_id, language='sv'):
     if language is not None and not is_valid_language(language):
         return jsonify({"error": "Invalid language."}), 400
 
+    # Get base metadata including visibility status from the database
     base_row, message, status_code = get_publication_metadata_base_row(
         project,
         p_id,
@@ -779,6 +780,7 @@ def get_publication_metadata(project, publication_id, language='sv'):
     if not can_show:
         return jsonify({"error": message}), 403
 
+    # Try serving metadata from prerendered file if prerendering enabled
     prerender_json = project_config.get("prerender_json", False)
 
     if prerender_json:
@@ -790,6 +792,8 @@ def get_publication_metadata(project, publication_id, language='sv'):
         if prerendered_metadata is not None:
             return jsonify(prerendered_metadata), 200
 
+    # Fall back to constructing metadata on demand
+    # Get additional metadata (manuscripts, facsimiles...) from the database
     db_metadata, message, status_code = get_publication_metadata_from_db(
         project,
         p_id,
@@ -806,6 +810,7 @@ def get_publication_metadata(project, publication_id, language='sv'):
         )
         return jsonify({"error": message}), status_code
 
+    # Construct the final response object
     response_data, response_status = construct_publication_metadata_response(
         db_metadata,
         project_config

--- a/sls_api/endpoints/metadata.py
+++ b/sls_api/endpoints/metadata.py
@@ -849,6 +849,7 @@ def get_publication_metadata(project, publication_id, language='sv'):
         with db_engine.connect() as connection:
             manuscript_statement = (
                 sqlalchemy.sql.select(
+                    manuscript_table.c.id,
                     manuscript_table.c.name,
                     manuscript_table.c.original_filename,
                     manuscript_table.c.sort_order,
@@ -881,6 +882,59 @@ def get_publication_metadata(project, publication_id, language='sv'):
             "error": "Unexpected error getting publication metadata."
         }), 500
 
+    # Get facsimiles linked to the publication
+    try:
+        facsimile_table = get_table("publication_facsimile")
+        facsimile_collection_table = get_table(
+            "publication_facsimile_collection"
+        )
+
+        with db_engine.connect() as connection:
+            facsimile_statement = (
+                sqlalchemy.sql.select(
+                    facsimile_table.c.id,
+                    facsimile_table.c.publication_facsimile_collection_id,
+                    facsimile_table.c.publication_manuscript_id,
+                    facsimile_table.c.page_nr,
+                    facsimile_table.c.priority,
+                    facsimile_collection_table.c.title,
+                    facsimile_collection_table.c.number_of_pages,
+                    facsimile_collection_table.c.description,
+                    facsimile_collection_table.c.external_url,
+                )
+                .select_from(
+                    facsimile_table.join(
+                        facsimile_collection_table,
+                        facsimile_table.c.publication_facsimile_collection_id == (
+                            facsimile_collection_table.c.id
+                        )
+                    )
+                )
+                .where(facsimile_table.c.publication_id == p_id)
+                .where(facsimile_table.c.deleted < 1)
+                .where(facsimile_collection_table.c.deleted < 1)
+                .order_by(
+                    facsimile_table.c.priority,
+                    facsimile_table.c.id
+                )
+            )
+            facsimiles = [
+                dict(facsimile)
+                for facsimile in connection.execute(
+                    facsimile_statement
+                ).mappings().all()
+            ]
+    except Exception:
+        logger.exception(
+            "Unexpected error getting publication facsimiles for %s/%s",
+            project,
+            publication_id
+        )
+        return jsonify({
+            "error": "Unexpected error getting publication metadata."
+        }), 500
+
+    # Response
     return jsonify({
         "publication_id": p_id,
         "collection_id": row["collection_id"],
@@ -890,7 +944,8 @@ def get_publication_metadata(project, publication_id, language='sv'):
         "publication_genre": row["publication_genre"],
         "publication_date": row["publication_date"],
         "publication_language": row["publication_language"],
-        "manuscripts": manuscripts
+        "manuscripts": manuscripts,
+        "facsimiles": facsimiles
     }), 200
 
 

--- a/sls_api/endpoints/metadata.py
+++ b/sls_api/endpoints/metadata.py
@@ -745,6 +745,7 @@ def get_publication_metadata(project, publication_id, language='sv'):
     """
     Get metadata for a given publication.
     """
+    # Validate parameters
     project_config = get_project_config(project)
     if project_config is None:
         return jsonify({"error": f"The project '{project}' does not exist."}), 400
@@ -759,6 +760,7 @@ def get_publication_metadata(project, publication_id, language='sv'):
     if language is not None and not is_valid_language(language):
         return jsonify({"error": "Invalid language."}), 400
 
+    # Get core data of publication and collection from the database
     try:
         project_table = get_table("project")
         collection_table = get_table("publication_collection")
@@ -776,6 +778,7 @@ def get_publication_metadata(project, publication_id, language='sv'):
                     ).label("collection_title"),
                     collection_table.c.published.label("collection_published"),
                     publication_table.c.name.label("publication_title"),
+                    publication_table.c.original_filename.label("publication_filepath"),
                     publication_table.c.published.label("publication_published"),
                     publication_table.c.genre.label("publication_genre"),
                     publication_table.c.original_publication_date.label(
@@ -833,14 +836,61 @@ def get_publication_metadata(project, publication_id, language='sv'):
     if not can_show:
         return jsonify({"error": message}), 403
 
+    manuscript_published_status = (
+        1
+        if project_config["show_internally_published"]
+        else 2
+    )
+
+    # Get manuscripts linked to the publication
+    try:
+        manuscript_table = get_table("publication_manuscript")
+
+        with db_engine.connect() as connection:
+            manuscript_statement = (
+                sqlalchemy.sql.select(
+                    manuscript_table.c.name,
+                    manuscript_table.c.original_filename,
+                    manuscript_table.c.sort_order,
+                    manuscript_table.c.language,
+                    manuscript_table.c.published,
+                )
+                .where(manuscript_table.c.publication_id == p_id)
+                .where(manuscript_table.c.deleted < 1)
+                .where(
+                    manuscript_table.c.published >= manuscript_published_status
+                )
+                .order_by(
+                    manuscript_table.c.sort_order,
+                    manuscript_table.c.name
+                )
+            )
+            manuscripts = [
+                dict(manuscript)
+                for manuscript in connection.execute(
+                    manuscript_statement
+                ).mappings().all()
+            ]
+    except Exception:
+        logger.exception(
+            "Unexpected error getting publication manuscripts for %s/%s",
+            project,
+            publication_id
+        )
+        return jsonify({
+            "error": "Unexpected error getting publication metadata."
+        }), 500
+
     return jsonify({
-        "id": p_id,
+        "publication_id": p_id,
         "collection_id": row["collection_id"],
         "collection_title": row["collection_title"],
         "publication_title": row["publication_title"],
+        "publication_filepath": row["publication_filepath"],
         "publication_genre": row["publication_genre"],
         "publication_date": row["publication_date"],
-        "publication_language": row["publication_language"]
+        "publication_language": row["publication_language"],
+        "manuscripts": manuscripts
     }), 200
 
 

--- a/sls_api/endpoints/metadata.py
+++ b/sls_api/endpoints/metadata.py
@@ -12,7 +12,8 @@ from werkzeug.security import safe_join
 from sls_api.endpoints.generics import can_show_published_values, \
     db_engine, get_project_config, get_project_id_from_name, path_hierarchy, \
     select_all_from_table, flatten_json, get_first_valid_item_from_toc, \
-    int_or_none, get_table, is_valid_language, reader_auth_required
+    int_or_none, get_table, is_valid_language, reader_auth_required, \
+    construct_publication_metadata_response
 
 meta = Blueprint('metadata', __name__, url_prefix="/digitaledition")
 
@@ -825,22 +826,19 @@ def get_publication_metadata(project, publication_id, language='sv'):
     if row is None:
         return jsonify({"error": "Content does not exist."}), 404
 
+    show_internal = project_config.get("show_internally_published", False)
     can_show, message = can_show_published_values(
         [
             row["project_published"],
             row["collection_published"],
             row["publication_published"]
         ],
-        project_config["show_internally_published"]
+        show_internal
     )
     if not can_show:
         return jsonify({"error": message}), 403
 
-    manuscript_published_status = (
-        1
-        if project_config["show_internally_published"]
-        else 2
-    )
+    manuscript_published_status = (1 if show_internal else 2)
 
     # Get manuscripts linked to the publication
     try:
@@ -934,8 +932,8 @@ def get_publication_metadata(project, publication_id, language='sv'):
             "error": "Unexpected error getting publication metadata."
         }), 500
 
-    # Response
-    return jsonify({
+    # Dictionary with publication metadata from the database
+    db_metadata = {
         "publication_id": p_id,
         "collection_id": row["collection_id"],
         "collection_title": row["collection_title"],
@@ -946,7 +944,13 @@ def get_publication_metadata(project, publication_id, language='sv'):
         "publication_language": row["publication_language"],
         "manuscripts": manuscripts,
         "facsimiles": facsimiles
-    }), 200
+    }
+
+    response_data, response_status = construct_publication_metadata_response(
+        db_metadata,
+        project_config
+    )
+    return jsonify(response_data), response_status
 
 
 def list_tooltips(table):

--- a/sls_api/endpoints/metadata.py
+++ b/sls_api/endpoints/metadata.py
@@ -934,6 +934,7 @@ def get_publication_metadata(project, publication_id, language='sv'):
 
     # Dictionary with publication metadata from the database
     db_metadata = {
+        "metadata_language": language,
         "publication_id": p_id,
         "collection_id": row["collection_id"],
         "collection_title": row["collection_title"],

--- a/sls_api/endpoints/metadata.py
+++ b/sls_api/endpoints/metadata.py
@@ -15,7 +15,7 @@ from sls_api.endpoints.generics import \
     get_prerendered_publication_metadata_content, \
     get_publication_metadata_base_row, get_publication_metadata_from_db, \
     select_all_from_table, flatten_json, get_first_valid_item_from_toc, \
-    int_or_none, get_table, is_valid_language, reader_auth_required
+    int_or_none, is_valid_language, reader_auth_required
 
 meta = Blueprint('metadata', __name__, url_prefix="/digitaledition")
 

--- a/sls_api/endpoints/metadata.py
+++ b/sls_api/endpoints/metadata.py
@@ -9,10 +9,10 @@ import sqlalchemy.sql
 from urllib.parse import unquote
 from werkzeug.security import safe_join
 
-from sls_api.endpoints.generics import db_engine, get_project_config, \
-    get_project_id_from_name, path_hierarchy, select_all_from_table, \
-    flatten_json, get_first_valid_item_from_toc, int_or_none, \
-    is_valid_language, reader_auth_required
+from sls_api.endpoints.generics import can_show_published_values, \
+    db_engine, get_project_config, get_project_id_from_name, path_hierarchy, \
+    select_all_from_table, flatten_json, get_first_valid_item_from_toc, \
+    int_or_none, get_table, is_valid_language, reader_auth_required
 
 meta = Blueprint('metadata', __name__, url_prefix="/digitaledition")
 
@@ -736,6 +736,87 @@ def get_urn(project, url, legacy_id=None):
             return_data.append(row._asdict())
     connection.close()
     return jsonify(return_data), 200
+
+
+@meta.route("/<project>/publications/<publication_id>/metadata/<language>", methods=["GET"])
+@meta.route("/<project>/publications/<publication_id>/metadata", methods=["GET"])
+@reader_auth_required()
+def get_publication_metadata(project, publication_id, language='sv'):
+    """
+    Get metadata for a given publication.
+    """
+    project_config = get_project_config(project)
+    if project_config is None:
+        return jsonify({"error": f"The project '{project}' does not exist."}), 400
+
+    if project_config.get("file_root") is None:
+        return jsonify({"error": f"File root missing from '{project}' project config."}), 500
+
+    p_id = int_or_none(publication_id)
+    if p_id is None or p_id < 1:
+        return jsonify({"error": "Invalid publication_id."}), 400
+
+    if language is not None and not is_valid_language(language):
+        return jsonify({"error": "Invalid language."}), 400
+
+    try:
+        project_table = get_table("project")
+        collection_table = get_table("publication_collection")
+        publication_table = get_table("publication")
+
+        with db_engine.connect() as connection:
+            statement = (
+                sqlalchemy.sql.select(
+                    project_table.c.published.label("project_published"),
+                    collection_table.c.id.label("collection_id"),
+                    collection_table.c.published.label("collection_published"),
+                    publication_table.c.name.label("publication_title"),
+                    publication_table.c.published.label("publication_published"),
+                    publication_table.c.genre.label("publication_genre"),
+                    publication_table.c.original_publication_date.label("publication_date"),
+                    publication_table.c.language.label("publication_language"),
+                )
+                .select_from(
+                    project_table
+                    .join(
+                        collection_table,
+                        collection_table.c.project_id == project_table.c.id,
+                    )
+                    .join(
+                        publication_table,
+                        publication_table.c.publication_collection_id == collection_table.c.id
+                    )
+                )
+                .where(project_table.c.name == str(project))
+                .where(publication_table.c.id == p_id)
+                .where(project_table.c.deleted < 1)
+                .where(collection_table.c.deleted < 1)
+                .where(publication_table.c.deleted < 1)
+            )
+            row = connection.execute(statement).mappings().first()
+    except Exception:
+        logger.exception(
+            "Unexpected error getting publication metadata for %s/%s",
+            project,
+            publication_id
+        )
+        return jsonify({"error": "Unexpected error getting publication metadata."}), 500
+
+    if row is None:
+        return jsonify({"error": "Content does not exist."}), 404
+
+    can_show, message = can_show_published_values(
+        [row["project_published"], row["collection_published"], row["publication_published"]],
+        project_config["show_internally_published"]
+    )
+    if not can_show:
+        return jsonify({"error": message}), 403
+
+    return jsonify({
+        "id": p_id,
+        "collection_id": row["collection_id"],
+        "collection_legacy_id": row["col_legacy_id"]
+    }), 200
 
 
 def list_tooltips(table):

--- a/sls_api/endpoints/metadata.py
+++ b/sls_api/endpoints/metadata.py
@@ -768,7 +768,8 @@ def get_publication_metadata(project, publication_id, language='sv'):
     base_row, message, status_code = get_publication_metadata_base_row(
         project,
         p_id,
-        language
+        language,
+        project_config
     )
     if base_row is None:
         return jsonify({"error": message}), status_code

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -1710,19 +1710,22 @@ def check_publication_mtimes_and_publish_files(
 
         if prerender_json:
             # * Prerender publication metadata
-            # This is done regardless of force_publish value.
 
-            for language in frontend_languages:
-                metadata_file = prerender_publication_metadata(
-                    project,
-                    project_config,
-                    publication_id,
-                    language,
-                    saxon_proc,
-                    publication_metadata_xslt_exec
-                )
-                if metadata_file is not None:
-                    json_changes.add(metadata_file)
+            # This is done regardless of force_publish value. Prerendering
+            # metadata for multilingual reading-texts is not supported.
+
+            if not is_multilingual:
+                for language in frontend_languages:
+                    metadata_file = prerender_publication_metadata(
+                        project,
+                        project_config,
+                        publication_id,
+                        language,
+                        saxon_proc,
+                        publication_metadata_xslt_exec
+                    )
+                    if metadata_file is not None:
+                        json_changes.add(metadata_file)
 
         # ****** VARIANTS ******
         # Process all variants belonging to this publication

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -909,7 +909,10 @@ def save_prerendered_json(
         return None
 
     try:
-        json_text = json.dumps(content, ensure_ascii=False, indent=2)
+        json_text = json.dumps(content,
+                               ensure_ascii=False,
+                               indent=2,
+                               sort_keys=True)
         with open(output_filepath, "w", encoding="utf-8") as outfile:
             outfile.write(ensure_trailing_newline(json_text))
     except Exception:

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -951,16 +951,15 @@ def prerender_publication_metadata(
         )
         return None
 
-    response_project_config = project_config
-    if saxon_proc is None or saxon_xslt_exec is None:
-        response_project_config = dict(project_config)
-        response_project_config["use_saxon_xslt"] = False
-
     response_data, response_status = construct_publication_metadata_response(
         db_metadata,
-        response_project_config,
+        project_config,
         saxon_processor=saxon_proc,
-        xslt_exec=saxon_xslt_exec
+        xslt_exec=saxon_xslt_exec,
+        use_xslt_transformation=(
+            saxon_proc is not None and
+            saxon_xslt_exec is not None
+        )
     )
     if response_status != 200:
         logger.error(
@@ -1220,7 +1219,8 @@ def check_publication_mtimes_and_publish_files(
     # Flag for prerendering JSON data
     prerender_json: bool = project_config.get("prerender_json", False)
 
-    # Flag for using the Saxon XSLT processor for prerender transformations
+    # Flag for using the Saxon XSLT processor for XML-to-HTML prerender
+    # transformations.
     use_saxon_for_prerender: bool = project_config.get("use_saxon_xslt", False)
 
     frontend_languages = get_project_frontend_languages(project_config)
@@ -1383,7 +1383,7 @@ def check_publication_mtimes_and_publish_files(
     if (
         use_xslt_processing or
         (prerender_html and use_saxon_for_prerender) or
-        (prerender_json and use_saxon_for_prerender)
+        prerender_json
     ):
         # Initialise a Saxon processor and Saxon XSLT 3.0 processor
         # Documentation for SaxonC's Python API:
@@ -1421,7 +1421,7 @@ def check_publication_mtimes_and_publish_files(
             )
         )
 
-    if prerender_json and use_saxon_for_prerender:
+    if prerender_json:
         # Compile the XSLT stylesheets used to prerender JSON data.
         # The compiled Saxon stylesheets are stored in a dictionary where
         # the JSON output types are keys and the compiled stylesheets are

--- a/sls_api/scripts/publisher.py
+++ b/sls_api/scripts/publisher.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import logging
 import os
 import sys
@@ -14,14 +15,19 @@ from werkzeug.security import safe_join
 
 from sls_api.endpoints.generics import config, db_engine, \
     changed_by_size_or_hash, \
+    construct_publication_metadata_response, \
     ensure_trailing_newline, \
     file_fingerprint, \
+    get_project_frontend_languages, \
     get_project_id_from_name, \
+    get_publication_metadata_from_db, \
     get_table, \
     int_or_none, \
     transform_xml, \
     PRERENDERED_HTML_PATH_IN_PROJECT_ROOT, \
-    XSL_PATH_MAP_FOR_HTML_TRANSFORMATIONS
+    PRERENDERED_JSON_PATH_MAP_IN_PROJECT_ROOT, \
+    XSL_PATH_MAP_FOR_HTML_TRANSFORMATIONS, \
+    XSL_PATH_MAP_FOR_JSON_TRANSFORMATIONS
 from sls_api.endpoints.tools.files import run_git_command, update_files_in_git_repo
 from sls_api.scripts.CTeiDocument import CTeiDocument
 from sls_api.scripts.saxon_xml_document import SaxonXMLDocument
@@ -344,28 +350,27 @@ def construct_notes_xml(comments: List[Dict[str, Any]], comment_positions: Dict[
 def compile_xslt_stylesheets(
         project_file_root: str,
         xslt_proc: Optional[PyXslt30Processor],
-        xml_to_html_stylesheets: bool = False
+        xsl_map: Mapping[str, str]
 ) -> Dict[str, Optional[PyXsltExecutable]]:
     """
     Compiles the XSLT stylesheets in the project files to Saxon XSLT
-    executables. If `xml_to_html_stylesheets` is True, it compiles the
-    stylesheets that transform web XML files to HTML, otherwise it
-    compiles the stylesheets that transform the original XML files to
-    web XML files.
+    executables.
+
+    Args:
+        project_file_root: Absolute root path of the project files. The
+            stylesheet paths in `xsl_map` are resolved relative to this path.
+        xslt_proc: Saxon XSLT 3.0 processor used to compile the stylesheets.
+            If None, no stylesheets are compiled and all values in the returned
+            dictionary are None.
+        xsl_map: Mapping where each key identifies a stylesheet type and each
+            value is the stylesheet path relative to `project_file_root`.
 
     Returns:
-    - A dictionary where the text types (est, com, ms ...) are keys
-    and the compiled stylesheets are values. If a stylesheet for a
-    text type can't be compiled, it's value will be set to None.
+    - A dictionary where the XSLT map keys are keys and the compiled
+    stylesheets are values. If a stylesheet can't be compiled, its value
+    will be set to None.
     """
     xslt_execs: Dict[str, Optional[PyXsltExecutable]] = {}
-
-    if xml_to_html_stylesheets:
-        # Stylesheets for web XML to HTML transformation
-        xsl_map = XSL_PATH_MAP_FOR_HTML_TRANSFORMATIONS
-    else:
-        # Stylesheets for web XML transformation
-        xsl_map = XSL_PATH_MAP_FOR_PUBLISHING
 
     for type_key, xsl_path in xsl_map.items():
         xsl_full_path = safe_join(project_file_root, xsl_path)
@@ -886,6 +891,113 @@ def transform_and_save(
     return None
 
 
+def save_prerendered_json(
+        output_filepath: str,
+        content: Mapping[str, Any]
+) -> Optional[str]:
+    """
+    Save prerendered JSON and return the file path if the file changed.
+    """
+    pre_sig = file_fingerprint(output_filepath)
+    output_dirpath = os.path.dirname(output_filepath)
+
+    try:
+        if output_dirpath:
+            os.makedirs(output_dirpath, exist_ok=True)
+    except Exception:
+        logger.exception("Error making dirs for path %s", output_dirpath)
+        return None
+
+    try:
+        json_text = json.dumps(content, ensure_ascii=False, indent=2)
+        with open(output_filepath, "w", encoding="utf-8") as outfile:
+            outfile.write(ensure_trailing_newline(json_text))
+    except Exception:
+        logger.exception("Unexpected error saving %s", output_filepath)
+        return None
+
+    if changed_by_size_or_hash(pre_sig, output_filepath):
+        return output_filepath
+
+    return None
+
+
+def prerender_publication_metadata(
+        project: str,
+        project_config: Mapping[str, Any],
+        publication_id: int,
+        language: str,
+        saxon_proc: Optional[PySaxonProcessor],
+        saxon_xslt_exec: Optional[PyXsltExecutable]
+) -> Optional[str]:
+    """
+    Transform and save publication metadata JSON for one publication language.
+    """
+    db_metadata, message, status_code = get_publication_metadata_from_db(
+        project,
+        publication_id,
+        language,
+        project_config
+    )
+    if db_metadata is None:
+        logger.error(
+            "Failed to prerender publication metadata for %s/%s/%s: %s "
+            "(status %s).",
+            project,
+            publication_id,
+            language,
+            message,
+            status_code
+        )
+        return None
+
+    response_project_config = project_config
+    if saxon_proc is None or saxon_xslt_exec is None:
+        response_project_config = dict(project_config)
+        response_project_config["use_saxon_xslt"] = False
+
+    response_data, response_status = construct_publication_metadata_response(
+        db_metadata,
+        response_project_config,
+        saxon_processor=saxon_proc,
+        xslt_exec=saxon_xslt_exec
+    )
+    if response_status != 200:
+        logger.error(
+            "Failed to prerender publication metadata for %s/%s/%s: "
+            "metadata transformation returned status %s.",
+            project,
+            publication_id,
+            language,
+            response_status
+        )
+        return None
+
+    json_dir = PRERENDERED_JSON_PATH_MAP_IN_PROJECT_ROOT.get(
+        "publication_metadata"
+    )
+    if json_dir is None:
+        logger.error("No JSON output path configured for publication metadata.")
+        return None
+
+    output_filepath = safe_join(
+        project_config.get("file_root", ""),
+        json_dir,
+        f"{publication_id}_{language}_metadata.json"
+    )
+    if output_filepath is None:
+        logger.error(
+            "Failed to prerender publication metadata for %s/%s/%s: "
+            "unable to form safe JSON path.",
+            project,
+            publication_id,
+            language
+        )
+        return None
+
+    return save_prerendered_json(output_filepath, response_data)
+
+
 def prerender_xml_to_html(
         project_config: Mapping[str, Any],
         xml_filepath: str,
@@ -1095,7 +1207,7 @@ def check_publication_mtimes_and_publish_files(
         return False
 
     # If publication_ids is a tuple of ints, we're (re)publishing a
-    # certain publication(s).Explicitly set force_publish in this
+    # certain publication(s). Explicitly set force_publish in this
     # instance, so we force-generate files for publishing (this
     # overrides mtime checks).
     publish_certain_ids: bool = isinstance(publication_ids, tuple)
@@ -1105,13 +1217,24 @@ def check_publication_mtimes_and_publish_files(
     # Flag for prerendering XML to HTML
     prerender_html: bool = project_config.get("prerender_html", False)
 
+    # Flag for prerendering JSON data
+    prerender_json: bool = project_config.get("prerender_json", False)
+
     # Flag for using the Saxon XSLT processor for prerender transformations
     use_saxon_for_prerender: bool = project_config.get("use_saxon_xslt", False)
+
+    frontend_languages = get_project_frontend_languages(project_config)
 
     if prerender_html:
         xslt_proc_name = "Saxon" if use_saxon_for_prerender else "lxml"
         logger.info("Prerendering enabled, using %s for transformations.",
                     xslt_proc_name)
+
+    if prerender_json:
+        logger.info(
+            "JSON prerendering enabled. Frontend languages: %s",
+            ", ".join(frontend_languages)
+        )
 
     # Clear cache of collection legacy ids
     clear_collection_legacy_id_cache()
@@ -1255,8 +1378,13 @@ def check_publication_mtimes_and_publish_files(
     xslt_proc: Optional[PyXslt30Processor] = None
     xml_xslt_execs: Optional[Dict[str, Optional[PyXsltExecutable]]] = None
     html_xslt_execs: Optional[Dict[str, Optional[PyXsltExecutable]]] = None
+    json_xslt_execs: Optional[Dict[str, Optional[PyXsltExecutable]]] = None
 
-    if use_xslt_processing or (prerender_html and use_saxon_for_prerender):
+    if (
+        use_xslt_processing or
+        (prerender_html and use_saxon_for_prerender) or
+        (prerender_json and use_saxon_for_prerender)
+    ):
         # Initialise a Saxon processor and Saxon XSLT 3.0 processor
         # Documentation for SaxonC's Python API:
         # https://www.saxonica.com/saxon-c/doc12/html/saxonc.html
@@ -1271,7 +1399,11 @@ def check_publication_mtimes_and_publish_files(
         # stylesheets are values. If a stylesheet for a text type can't be
         # compiled, it's value will be set to None.
         xml_xslt_execs: Dict[str, Optional[PyXsltExecutable]] = (
-            compile_xslt_stylesheets(file_root, xslt_proc)
+            compile_xslt_stylesheets(
+                file_root,
+                xslt_proc,
+                XSL_PATH_MAP_FOR_PUBLISHING
+            )
         )
 
     if prerender_html and use_saxon_for_prerender:
@@ -1282,15 +1414,37 @@ def check_publication_mtimes_and_publish_files(
         # stylesheets are values. If a stylesheet for a text type can't be
         # compiled, it's value will be set to None.
         html_xslt_execs: Dict[str, Optional[PyXsltExecutable]] = (
-            compile_xslt_stylesheets(file_root,
-                                     xslt_proc,
-                                     xml_to_html_stylesheets=True)
+            compile_xslt_stylesheets(
+                file_root,
+                xslt_proc,
+                XSL_PATH_MAP_FOR_HTML_TRANSFORMATIONS
+            )
         )
+
+    if prerender_json and use_saxon_for_prerender:
+        # Compile the XSLT stylesheets used to prerender JSON data.
+        # The compiled Saxon stylesheets are stored in a dictionary where
+        # the JSON output types are keys and the compiled stylesheets are
+        # values. If a stylesheet can't be compiled, its value will be None.
+        json_xslt_execs: Dict[str, Optional[PyXsltExecutable]] = (
+            compile_xslt_stylesheets(
+                file_root,
+                xslt_proc,
+                XSL_PATH_MAP_FOR_JSON_TRANSFORMATIONS
+            )
+        )
+        if json_xslt_execs.get("publication_metadata") is None:
+            logger.warning(
+                "Publication metadata XSLT could not be compiled. "
+                "Prerendering publication metadata JSON from database fields only."
+            )
 
     # Keep a list of changed XML files for later git commit
     xml_changes = set()
     # Keep a list of changed HTML files for later git commit
     html_changes = set()
+    # Keep a list of changed JSON files for later git commit
+    json_changes = set()
 
     pub_count = len(publication_rows)
     ms_count = len(manuscript_rows)
@@ -1303,7 +1457,11 @@ def check_publication_mtimes_and_publish_files(
     # to the generated web XML files.
 
     if pub_count:
-        logger.info("Processing reading texts, comments and variants of publications.")
+        logger.info("Processing reading texts, comments, and variants of publications.")
+
+    publication_metadata_xslt_exec = (
+        (json_xslt_execs or {}).get("publication_metadata")
+    )
 
     for idx, row in enumerate(publication_rows, start=1):
         p_row = dict(row)
@@ -1549,6 +1707,22 @@ def check_publication_mtimes_and_publish_files(
                                                       saxon_proc,
                                                       html_xslt_execs)
                 html_changes.update(com_html_file)
+
+        if prerender_json:
+            # * Prerender publication metadata
+            # This is done regardless of force_publish value.
+
+            for language in frontend_languages:
+                metadata_file = prerender_publication_metadata(
+                    project,
+                    project_config,
+                    publication_id,
+                    language,
+                    saxon_proc,
+                    publication_metadata_xslt_exec
+                )
+                if metadata_file is not None:
+                    json_changes.add(metadata_file)
 
         # ****** VARIANTS ******
         # Process all variants belonging to this publication
@@ -1933,6 +2107,14 @@ def check_publication_mtimes_and_publish_files(
         else:
             logger.info("No HTML changes made in publisher script run.")
 
+    if prerender_json:
+        # Log a summary of changed JSON-files.
+        if json_changes:
+            sorted_json_changes = sorted(json_changes)
+            logger.info("JSON changes made in publisher script run (%d):\n%s", len(json_changes), ", ".join(sorted_json_changes))
+        else:
+            logger.info("No JSON changes made in publisher script run.")
+
     # Log a summary of warnings and errors
     if logger_flags.had_warning and logger_flags.had_error:
         logger.info("*** There were WARNINGS and ERRORS during publisher script run! ***")
@@ -1941,8 +2123,8 @@ def check_publication_mtimes_and_publish_files(
     elif logger_flags.had_warning:
         logger.info("*** There were WARNINGS during publisher script run! ***")
 
-    # Merge the sets containing XML and HTML changes
-    all_changes = xml_changes.union(html_changes)
+    # Merge the sets containing XML, HTML and JSON changes
+    all_changes = xml_changes.union(html_changes).union(json_changes)
 
     if not no_git and len(all_changes) > 0:
         outputs = []

--- a/sls_api/scripts/saxon_xml_document.py
+++ b/sls_api/scripts/saxon_xml_document.py
@@ -208,9 +208,9 @@ class SaxonXMLDocument:
 
     def call_template_returning_string(
             self,
-            template: Optional[str]=None,
-            xslt_exec: Optional[PyXsltExecutable]=None,
-            parameters: Optional[Dict]=None
+            template: Optional[str] = None,
+            xslt_exec: Optional[PyXsltExecutable] = None,
+            parameters: Optional[Dict] = None
     ) -> str:
         """
         Invoke a transformation by calling a named template and return the result
@@ -233,7 +233,7 @@ class SaxonXMLDocument:
         exec = xslt_exec or self.compiled_xslt
         if exec is None:
             raise Exception("No XSLT executable could be resolved.")
-        
+
         # Initialize parameters as an empty dictionary if None is passed
         parameters = parameters or {}
 
@@ -284,7 +284,7 @@ class SaxonXMLDocument:
         """
         if self.xslt30_proc is None:
             self.xslt30_proc = self.saxon_proc.new_xslt30_processor()
-        
+
         self.compiled_xslt = self.xslt30_proc.compile_stylesheet(
             stylesheet_file=xslt_path,
             encoding="utf-8"

--- a/sls_api/scripts/saxon_xml_document.py
+++ b/sls_api/scripts/saxon_xml_document.py
@@ -2,7 +2,7 @@ import io
 import re
 from typing import Any, Dict, List, Optional
 
-from saxonche import PySaxonApiError, PySaxonProcessor, PyXdmNode, PyXdmValue, PyXsltExecutable
+from saxonche import PySaxonApiError, PySaxonProcessor, PyXdmNode, PyXdmValue, PyXsltExecutable, PyXslt30Processor
 
 
 class SaxonXMLDocument:
@@ -21,6 +21,10 @@ class SaxonXMLDocument:
     - saxon_proc (PySaxonProcessor): An instance of PySaxonProcessor for
       SaxonC operations.
     - namespaces (list): List of namespaces to declare for XPath evaluation.
+    - xslt30_proc (PyXslt30Processor): Optional instance of a Saxon XSLT 3.0
+      processor. Must have been created with the class `saxon_proc`.
+    - compiled_xslt (PyXsltExecutable): Optional compiled XSLT stylesheet.
+      Must have been created with the class `xslt30_proc`.
 
     Methods:
     - load_xml_file(filepath): Loads an XML document from a file and parses it.
@@ -57,13 +61,16 @@ class SaxonXMLDocument:
       initialization.
     - namespaces (list, optional): A list of dictionaries containing namespace
       mappings. Defaults to TEI and XML namespaces.
+    - xslt30_proc (PyXslt30Processorl, optional): An instance of a Saxon XSLT
+      3.0 processor. Must have been created with the passed PySaxonProcessor.
     """
 
     def __init__(
             self,
             saxon_proc: PySaxonProcessor,
             xml_filepath: str = "",
-            namespaces: Optional[List[Dict[str, str]]] = None
+            namespaces: Optional[List[Dict[str, str]]] = None,
+            xslt30_proc: Optional[PyXslt30Processor] = None
     ):
         """
         Initializes a SaxonXMLDocument instance.
@@ -92,6 +99,8 @@ class SaxonXMLDocument:
             {"prefix": "xml", "uri": "http://www.w3.org/XML/1998/namespace"},
             {"prefix": "tei", "uri": "http://www.tei-c.org/ns/1.0"}
         ]
+        self.xslt30_proc: Optional[PyXslt30Processor] = xslt30_proc
+        self.compiled_xslt: Optional[PyXsltExecutable] = None
 
         if xml_filepath:
             try:
@@ -197,6 +206,47 @@ class SaxonXMLDocument:
                                                     format_output)
         self._save_to_file(output_filepath=output_filepath)
 
+    def call_template_returning_string(
+            self,
+            template: Optional[str]=None,
+            xslt_exec: Optional[PyXsltExecutable]=None,
+            parameters: Optional[Dict]=None
+    ) -> str:
+        """
+        Invoke a transformation by calling a named template and return the result
+        as a string.
+
+        Parameters:
+        - template (str, optional): The name of the template to invoke. If None
+          is supplied then call the initial-template. Defaults to None.
+        - xslt_exec (PyXsltExecutable, optional): The compiled XSLT executable
+          to use for the transformation. If None is supplied then the XSLT
+          executable instantiated on the class will be used. Throws if no XSLT
+          executable can be resolved. Defaults to None.
+        - parameters (dict, optional): A dictionary with parameters for the XSLT
+          executable. Defaults to None.
+
+        Returns:
+        - str: Result of the transformation as a string.
+        """
+        # Use the class XSLT executable if none passed
+        exec = xslt_exec or self.compiled_xslt
+        if exec is None:
+            raise Exception("No XSLT executable could be resolved.")
+        
+        # Initialize parameters as an empty dictionary if None is passed
+        parameters = parameters or {}
+
+        # Clear any parameters previously set on the XSLT executable
+        exec.clear_parameters()
+
+        if parameters:
+            self._set_xslt_parameters_from_dict(exec, parameters)
+
+        result = exec.call_template_returning_string(template_name=template,
+                                                     encoding="utf-8")
+        return result
+
     def add_namespace(self, ns_prefix: str, ns_uri: str):
         """
         Adds the provided namespace to the `namespaces` attribute of the
@@ -220,6 +270,27 @@ class SaxonXMLDocument:
             }
         )
         return True
+
+    def compile_stylesheet(self, xslt_path: str) -> PyXsltExecutable:
+        """
+        Compiles the XSLT stylesheet to a PyXsltExecutable. If the class
+        has no PyXslt30Processor, one is created.
+
+        Parameters:
+        - xslt_path (str): path to the XSLT stylesheet to be compiled.
+
+        Returns:
+        - PyXsltExecutable: The compiled stylesheet.
+        """
+        if self.xslt30_proc is None:
+            self.xslt30_proc = self.saxon_proc.new_xslt30_processor()
+        
+        self.compiled_xslt = self.xslt30_proc.compile_stylesheet(
+            stylesheet_file=xslt_path,
+            encoding="utf-8"
+        )
+
+        return self.compiled_xslt
 
     def get_all_comment_ids(self) -> List[int]:
         """


### PR DESCRIPTION
## Summary

Adds a public publication metadata endpoint that returns metadata for a single publication, with optional project-specific XSLT enrichment and support for prerendered JSON responses.

The endpoint builds a metadata object from database data, verifies publication visibility using the same published-status logic as other publication endpoints, and can optionally pass the database metadata through a project-specific `publication-metadata.xsl` stylesheet to add metadata from XML files.

## New endpoint

Adds:

`GET /digitaledition/<project>/publications/<publication_id>/metadata`
`GET /digitaledition/<project>/publications/<publication_id>/metadata/<language>`

If `language` is omitted, it defaults to `sv`.

The endpoint:

- validates `project`, `file_root`, `publication_id`, and `language`
- verifies that the project, publication collection, and publication exist and are not deleted
- checks published status for project, collection, and publication
- respects `show_internally_published`
- returns `404` for missing content
- returns `403` for unpublished or non-public content
- returns `400` for invalid parameters

## Metadata response construction

The database metadata includes:

- metadata language
- publication id, title, genre, date, and language
- publication collection id and translated/default collection title
- linked comment filepath, filtered by deleted/published status
- linked manuscripts, filtered by deleted/published status
- linked variants, filtered by deleted/published status
- linked facsimiles and facsimile collection data, excluding deleted rows

If `xslt/publication-metadata.xsl` exists, the metadata is passed to the stylesheet as JSON through the `db-json` parameter. The stylesheet can then read additional metadata from publication/manuscript XML files and return the final response object as JSON. The stylesheet, if present, is always invoked with Saxon, not with lxml.

URI fields are generated and appended to the metadata from internal file path fields, so XSLT processing can access the XML files. Internal file path fields and the generated URI fields are removed from the metadata object before the response is sent.

If Saxon or the stylesheet is unavailable, the endpoint returns the sanitized database metadata directly.

## Prerendered JSON support

Adds support for prerendering publication metadata JSON in `sls_api/scripts/publisher.py`.

When `prerender_json` is enabled in the project config (treated as False if missing), the publisher writes metadata files to:

`json/publication-metadata/<publication_id>_<language>_metadata.json`

The endpoint checks publication visibility from the database on every request before serving a prerendered file. If the prerendered file is missing or invalid, the endpoint falls back to constructing the metadata on demand.

Publication metadata prerendering runs once per configured frontend language for each publication during publishing. It is currently disabled for the multilingual publishing path.

## New config flags

Adds `prerender_json`:

```prerender_json: False```

Controls whether JSON data, currently publication metadata (later also illustration data), is prerendered and served from files when available.

Adds `frontend_languages`:

```frontend_languages: ["sv"]```

Defines the language codes used when prerendering language-specific JSON files. If missing or invalid, the code falls back to `["sv"]`.

Existing `use_saxon_xslt` behavior:

- If `prerender_json: True`, publication metadata is prerendered with XSLT enrichment using Saxon when possible. The value of `use_saxon_xslt` does not affect this. XSLT enrichment of metadata using lxml is not supported because lxml does not support XSLT 3.0.
- If the metadata XSLT cannot be compiled, prerendering falls back to database-only metadata.

`prerender_html` remains responsible only for HTML prerendering.